### PR TITLE
Reject invalid metric names

### DIFF
--- a/src/Prometheus/Metric.php
+++ b/src/Prometheus/Metric.php
@@ -5,6 +5,7 @@ namespace Prometheus;
 
 abstract class Metric
 {
+    const RE_METRIC_NAME = '/^[a-zA-Z_:][a-zA-Z0-9_:]*$/';
     protected $name;
     protected $help;
     protected $labels;
@@ -18,7 +19,11 @@ abstract class Metric
      */
     public function __construct($namespace, $name, $help, $labels = array())
     {
-        $this->name = Metric::metricName($namespace, $name);
+        $metricName = Metric::metricName($namespace, $name);
+        if (!preg_match(self::RE_METRIC_NAME, $metricName)) {
+            throw new \InvalidArgumentException("Invalid metric name: '" . $metricName . "'");
+        }
+        $this->name = $metricName;
         $this->help = $help;
         $this->labels = $labels;
     }

--- a/tests/Test/Prometheus/CounterTest.php
+++ b/tests/Test/Prometheus/CounterTest.php
@@ -86,4 +86,13 @@ class CounterTest extends PHPUnit_Framework_TestCase
             )
         );
     }
+
+    /**
+     * @test
+     * @expectedException \InvalidArgumentException
+     */
+    public function itShouldRejectInvalidMetricsNames()
+    {
+        new Counter('test', 'some metric invalid metric', 'help');
+    }
 }

--- a/tests/Test/Prometheus/GaugeTest.php
+++ b/tests/Test/Prometheus/GaugeTest.php
@@ -63,4 +63,13 @@ class GaugeTest extends PHPUnit_Framework_TestCase
         $this->assertThat($gauge->getHelp(), $this->equalTo('this is for testing'));
         $this->assertThat($gauge->getType(), $this->equalTo(Gauge::TYPE));
     }
+
+    /**
+     * @test
+     * @expectedException \InvalidArgumentException
+     */
+    public function itShouldRejectInvalidMetricsNames()
+    {
+        new Gauge('test', 'some metric invalid metric', 'help');
+    }
 }

--- a/tests/Test/Prometheus/HistogramTest.php
+++ b/tests/Test/Prometheus/HistogramTest.php
@@ -232,4 +232,14 @@ class HistogramTest extends PHPUnit_Framework_TestCase
     {
         new Histogram('test', 'some_metric', 'this is for testing', array('le'), array());
     }
+
+    /**
+     * @test
+     * @expectedException \InvalidArgumentException
+     */
+    public function itShouldRejectInvalidMetricsNames()
+    {
+        new Histogram('test', 'some invalid metric', 'help', array(), array(1));
+    }
+
 }


### PR DESCRIPTION
Fixes #4

Metrics must match this [regex](https://github.com/prometheus/client_python/blob/master/prometheus_client/core.py#L20).