### PR TITLE
Throw an exception when connecting to Redis fails

### DIFF
--- a/src/Prometheus/Storage/Exception.php
+++ b/src/Prometheus/Storage/Exception.php
@@ -1,0 +1,13 @@
+<?php
+
+
+namespace Prometheus\Storage;
+
+
+/**
+ * Exception thrown if an error occurs during metrics storage.
+ */
+class Exception extends \RuntimeException
+{
+
+}

--- a/src/Prometheus/Storage/RedisTest.php
+++ b/src/Prometheus/Storage/RedisTest.php
@@ -1,0 +1,20 @@
+<?php
+
+
+namespace Prometheus\Storage;
+
+
+class RedisTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     * @expectedException \Prometheus\Storage\Exception
+     * @expectedExceptionMessage Can't connect to Redis server
+     */
+    public function itShouldThrowAnExceptionOnConnectionFailure()
+    {
+        $redis = new Redis(array('host' => 'doesntexist.test'));
+        $redis->flushRedis();
+    }
+
+}


### PR DESCRIPTION
When the configured Redis server can't be reached throw an exception.