### PR TITLE
Put Exception into own namespace

### DIFF
--- a/src/Prometheus/Exception/StorageException.php
+++ b/src/Prometheus/Exception/StorageException.php
@@ -1,13 +1,13 @@
 <?php
 
 
-namespace Prometheus\Storage;
+namespace Prometheus\Exception;
 
 
 /**
  * Exception thrown if an error occurs during metrics storage.
  */
-class Exception extends \RuntimeException
+class StorageException extends \Exception
 {
 
 }

--- a/src/Prometheus/Storage/Redis.php
+++ b/src/Prometheus/Storage/Redis.php
@@ -5,6 +5,7 @@ namespace Prometheus\Storage;
 
 use Prometheus\Collector;
 use Prometheus\Counter;
+use Prometheus\Exception\StorageException;
 use Prometheus\Gauge;
 use Prometheus\Histogram;
 use Prometheus\MetricFamilySamples;
@@ -76,7 +77,7 @@ class Redis implements Adapter
 
     /**
      * @return MetricFamilySamples[]
-     * @throws Exception
+     * @throws StorageException
      */
     public function collect()
     {
@@ -90,7 +91,7 @@ class Redis implements Adapter
     }
 
     /**
-     * @throws Exception
+     * @throws StorageException
      */
     public function store($command, Collector $metric, Sample $sample)
     {
@@ -140,7 +141,7 @@ class Redis implements Adapter
     }
 
     /**
-     * @throws Exception
+     * @throws StorageException
      */
     private function openConnection()
     {
@@ -152,7 +153,7 @@ class Redis implements Adapter
             }
             $this->redis->setOption(\Redis::OPT_READ_TIMEOUT, $this->options['read_timeout']);
         } catch (\RedisException $e) {
-            throw new Exception("Can't connect to Redis server", 0, $e);
+            throw new StorageException("Can't connect to Redis server", 0, $e);
         }
     }
 

--- a/src/Prometheus/Storage/RedisTest.php
+++ b/src/Prometheus/Storage/RedisTest.php
@@ -8,7 +8,7 @@ class RedisTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @test
-     * @expectedException \Prometheus\Storage\Exception
+     * @expectedException \Prometheus\Exception\StorageException
      * @expectedExceptionMessage Can't connect to Redis server
      */
     public function itShouldThrowAnExceptionOnConnectionFailure()


### PR DESCRIPTION
This prevents clashes with `\Exception`.