### PR TITLE
Use APC as a storage adapter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,19 @@
 language: php
 php:
   - 5.6
-  - 5.3
 
 services:
   - redis-server
 
 before_script:
+  - echo yes | pecl install apcu-4.0.11
+  - echo "apc.enabled = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+  - echo "apc.enable_cli = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - echo "extension = redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - composer self-update
   - composer install --no-interaction --prefer-source --dev
   - phpenv rehash
+  - php -i
 
 script:
   - vendor/bin/phpunit --verbose --colors

--- a/README.md
+++ b/README.md
@@ -98,5 +98,10 @@ Just start the nginx, fpm & Redis setup with docker-compose:
 ```
 composer require guzzlehttp/guzzle=~6.0
 docker-compose up
-vendor/bin/phpunit tests/Test/BlackBoxTest.php
+```
+Pick the adapter you want to test.
+
+```
+ADAPTER=redis vendor/bin/phpunit tests/Test/BlackBoxTest.php
+ADAPTER=apc vendor/bin/phpunit tests/Test/BlackBoxTest.php
 ```

--- a/README.md
+++ b/README.md
@@ -7,13 +7,12 @@
 This library uses Redis or APCu to do the client side aggregation.
 If using Redis, we recommend to run a local Redis instance next to your PHP workers.
 
-## Why Redis?
+## How does it work?
 
 Usually PHP worker processes don't share any state.
-
-We decided to use Redis because:
- * It is easy to deploy as a sidecar to the PHP worker processes (see [docker-compose.yml](docker-compose.yml)).
- * It provides us with easy to use concurrency mechanisms we need for the metric aggregation (e.g. `incrByFloat`).
+You can pick from two adapters.
+One uses Redis the other APC.
+While the former needs a separate binary running, the latter just needs the [APC](https://pecl.php.net/package/APCU) extension to be installed.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 [![Code Climate](https://codeclimate.com/github/Jimdo/prometheus_client_php.png)](https://codeclimate.com/github/Jimdo/prometheus_client_php)
 
 
-This library uses Redis to do the client side aggregation.
-We recommend to run a local Redis instance next to your PHP workers.
+This library uses Redis or APCu to do the client side aggregation.
+If using Redis, we recommend to run a local Redis instance next to your PHP workers.
 
 ## Why Redis?
 
@@ -14,10 +14,6 @@ Usually PHP worker processes don't share any state.
 We decided to use Redis because:
  * It is easy to deploy as a sidecar to the PHP worker processes (see [docker-compose.yml](docker-compose.yml)).
  * It provides us with easy to use concurrency mechanisms we need for the metric aggregation (e.g. `incrByFloat`).
-
-We think this could be implemented with APCu as well and we might do so in the future.
-Of course we would also appreciate a pull-request.
-
 
 ## Usage
 
@@ -73,8 +69,9 @@ Also look at the [examples](examples).
 
 ### Dependencies
 
-* PHP 5.3/5.6 (at least these versions are tested at the moment)
+* PHP 5.6
 * PHP Redis extension
+* PHP APCu extension
 * [Composer](https://getcomposer.org/doc/00-intro.md#installation-linux-unix-osx)
 * Redis
 

--- a/composer.json
+++ b/composer.json
@@ -11,15 +11,15 @@
         }
     ],
     "require": {
-        "php": ">=5.6.3",
-        "ext-redis": "*",
-        "ext-apc": "*"
+        "php": ">=5.6.3"
     },
     "require-dev": {
         "phpunit/phpunit": "4.1.0"
     },
     "suggest": {
-        "guzzlehttp/guzzle": "~6.0 for running the blackbox tests."
+        "guzzlehttp/guzzle": "~6.0 for running the blackbox tests.",
+        "ext-redis": "Required if using Redis.",
+        "ext-apc": "Required if using APCu."
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -4,11 +4,16 @@
         {
             "name": "Joscha",
             "email": "joscha@schnipseljagd.org"
+        },
+        {
+            "name": "Jan Brauer",
+            "email": "jan.brauer@jimdo.com"
         }
     ],
     "require": {
-        "php": ">=5.3.3",
-        "ext-redis": "*"
+        "php": ">=5.6.3",
+        "ext-redis": "*",
+        "ext-apc": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "4.1.0"

--- a/examples/flush_adapter.php
+++ b/examples/flush_adapter.php
@@ -1,0 +1,16 @@
+<?php
+require __DIR__ . '/../vendor/autoload.php';
+
+$adapter = $_GET['adapter'];
+
+if ($adapter == 'redis') {
+    define('REDIS_HOST', isset($_SERVER['REDIS_HOST']) ? $_SERVER['REDIS_HOST'] : '127.0.0.1');
+
+    $redisAdapter = new Prometheus\Storage\Redis(array('host' => REDIS_HOST));
+    $redisAdapter->flushRedis();
+}
+
+if ($adapter == 'apc') {
+    $apcAdapter = new Prometheus\Storage\APC();
+    $apcAdapter->flushAPC();
+}

--- a/examples/flush_redis.php
+++ b/examples/flush_redis.php
@@ -1,7 +1,0 @@
-<?php
-require __DIR__ . '/../vendor/autoload.php';
-
-define('REDIS_HOST', isset($_SERVER['REDIS_HOST']) ? $_SERVER['REDIS_HOST'] : '127.0.0.1');
-
-$redisAdapter = new Prometheus\Storage\Redis(array('host' => REDIS_HOST));
-$redisAdapter->flushRedis();

--- a/examples/metrics.php
+++ b/examples/metrics.php
@@ -6,8 +6,16 @@ use Prometheus\CollectorRegistry;
 use Prometheus\RenderTextFormat;
 use Prometheus\Storage\Redis;
 
-Redis::setDefaultOptions(array('host' => isset($_SERVER['REDIS_HOST']) ? $_SERVER['REDIS_HOST'] : '127.0.0.1'));
-$registry = CollectorRegistry::getDefault();
+$adapter = $_GET['adapter'];
+
+if ($adapter == 'redis') {
+    Redis::setDefaultOptions(array('host' => isset($_SERVER['REDIS_HOST']) ? $_SERVER['REDIS_HOST'] : '127.0.0.1'));
+    $adapter = new Prometheus\Storage\Redis();
+}
+if ($adapter == 'apc') {
+    $adapter = new Prometheus\Storage\APC();
+}
+$registry = new CollectorRegistry($adapter);
 $renderer = new RenderTextFormat();
 $result = $renderer->render($registry->getMetricFamilySamples());
 

--- a/examples/some_counter.php
+++ b/examples/some_counter.php
@@ -7,8 +7,16 @@ use Prometheus\Storage\Redis;
 
 error_log('c='. $_GET['c']);
 
-Redis::setDefaultOptions(array('host' => isset($_SERVER['REDIS_HOST']) ? $_SERVER['REDIS_HOST'] : '127.0.0.1'));
-$registry = CollectorRegistry::getDefault();
+$adapter = $_GET['adapter'];
+
+if ($adapter == 'redis') {
+    Redis::setDefaultOptions(array('host' => isset($_SERVER['REDIS_HOST']) ? $_SERVER['REDIS_HOST'] : '127.0.0.1'));
+    $adapter = new Prometheus\Storage\Redis();
+}
+if ($adapter == 'apc') {
+    $adapter = new Prometheus\Storage\APC();
+}
+$registry = new CollectorRegistry($adapter);
 
 $counter = $registry->registerCounter('test', 'some_counter', 'it increases', ['type']);
 $counter->incBy($_GET['c'], ['blue']);

--- a/examples/some_gauge.php
+++ b/examples/some_gauge.php
@@ -8,8 +8,16 @@ use Prometheus\Storage\Redis;
 
 error_log('c='. $_GET['c']);
 
-Redis::setDefaultOptions(array('host' => isset($_SERVER['REDIS_HOST']) ? $_SERVER['REDIS_HOST'] : '127.0.0.1'));
-$registry = CollectorRegistry::getDefault();
+$adapter = $_GET['adapter'];
+
+if ($adapter == 'redis') {
+    Redis::setDefaultOptions(array('host' => isset($_SERVER['REDIS_HOST']) ? $_SERVER['REDIS_HOST'] : '127.0.0.1'));
+    $adapter = new Prometheus\Storage\Redis();
+}
+if ($adapter == 'apc') {
+    $adapter = new Prometheus\Storage\APC();
+}
+$registry = new CollectorRegistry($adapter);
 
 $gauge = $registry->registerGauge('test', 'some_gauge', 'it sets', ['type']);
 $gauge->set($_GET['c'], ['blue']);

--- a/examples/some_histogram.php
+++ b/examples/some_histogram.php
@@ -7,8 +7,16 @@ use Prometheus\Storage\Redis;
 
 error_log('c='. $_GET['c']);
 
-Redis::setDefaultOptions(array('host' => isset($_SERVER['REDIS_HOST']) ? $_SERVER['REDIS_HOST'] : '127.0.0.1'));
-$registry = CollectorRegistry::getDefault();
+$adapter = $_GET['adapter'];
+
+if ($adapter == 'redis') {
+    Redis::setDefaultOptions(array('host' => isset($_SERVER['REDIS_HOST']) ? $_SERVER['REDIS_HOST'] : '127.0.0.1'));
+    $adapter = new Prometheus\Storage\Redis();
+}
+if ($adapter == 'apc') {
+    $adapter = new Prometheus\Storage\APC();
+}
+$registry = new CollectorRegistry($adapter);
 
 $histogram = $registry->registerHistogram('test', 'some_histogram', 'it observes', ['type'], [0.1, 1, 2, 3.5, 4, 5, 6, 7, 8, 9]);
 $histogram->observe($_GET['c'], ['blue']);

--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -1,5 +1,6 @@
 FROM php:5.6-fpm
 
 RUN pecl install redis-2.2.8 && docker-php-ext-enable redis
+RUN pecl install apcu-4.0.11 && docker-php-ext-enable apcu
 
 COPY www.conf /usr/local/etc/php-fpm.d/

--- a/src/Prometheus/Storage/APC.php
+++ b/src/Prometheus/Storage/APC.php
@@ -1,0 +1,100 @@
+<?php
+
+
+namespace Prometheus\Storage;
+
+
+use Prometheus\MetricFamilySamples;
+
+class APC implements Adapter
+{
+    const PROMETHEUS_PREFIX = 'prom';
+
+    /**
+     * @return MetricFamilySamples[]
+     */
+    public function collect()
+    {
+        /**
+         * @var MetricFamilySamples[]
+         */
+        $metrics = array();
+        foreach (new \APCIterator('user', '/^prom:counter:.*:meta/') as $counter) {
+            $metaData = json_decode($counter['value'], true);
+            $data = array(
+                'name' => $metaData['name'],
+                'help' => $metaData['help'],
+                'type' => $metaData['type'],
+                'labelNames' => $metaData['labelNames'],
+            );
+            foreach (new \APCIterator('user', '/^prom:counter:'. $metaData['name'] . ':.*:value/') as $value) {
+                $parts = explode(':',$value['key']);
+                $labelValues = $parts[3];
+                $data['samples'][] = array(
+                    'name' => $metaData['name'],
+                    'labelNames' => array(),
+                    'labelValues' => json_decode($labelValues),
+                    'value' => $value['value']
+                );
+            }
+            $metrics[] = new MetricFamilySamples($data);
+
+        }
+        return $metrics;
+    }
+
+    public function updateHistogram(array $data)
+    {
+        // TODO: Implement updateHistogram() method.
+    }
+
+    public function updateGauge(array $data)
+    {
+        // TODO: Implement updateGauge() method.
+    }
+
+    public function updateCounter(array $data)
+    {
+        $new = apc_add($this->valueKey($data), 0);
+        if ($new) {
+            apc_store($this->metaKey($data), json_encode($this->metaData($data)));
+        }
+        apc_inc($this->valueKey($data), $data['value']);
+    }
+
+    public function flushAPC()
+    {
+       apc_clear_cache('user');
+    }
+
+    /**
+     * @param array $data
+     * @return string
+     */
+    private function metaKey(array $data)
+    {
+        return implode(':', array(self::PROMETHEUS_PREFIX, $data['type'], $data['name'], 'meta'));
+    }
+
+    /**
+     * @param array $data
+     * @return string
+     */
+    private function valueKey(array $data)
+    {
+        return implode(':', array(self::PROMETHEUS_PREFIX, $data['type'], $data['name'], json_encode($data['labelValues']), 'value'));
+    }
+
+    /**
+     * @param array $data
+     * @return array
+     */
+    private function metaData(array $data)
+    {
+        $metricsMetaData = $data;
+        unset($metricsMetaData['value']);
+        unset($metricsMetaData['command']);
+        unset($metricsMetaData['labelValues']);
+        return $metricsMetaData;
+    }
+}

--- a/src/Prometheus/Storage/APC.php
+++ b/src/Prometheus/Storage/APC.php
@@ -218,7 +218,9 @@ class APC implements Adapter
             }
 
             // Compute all buckets
-            foreach (array_keys($histogramBuckets) as $labelValues) {
+            $labels = array_keys($histogramBuckets);
+            sort($labels);
+            foreach ($labels as $labelValues) {
                 $acc = 0;
                 $decodedLabelValues = json_decode($labelValues);
                 foreach ($data['buckets'] as $bucket) {
@@ -257,9 +259,8 @@ class APC implements Adapter
                     'value' => $this->fromInteger($histogramBuckets[$labelValues]['sum'])
                 );
 
-                $histograms[] = new MetricFamilySamples($data);
             }
-
+            $histograms[] = new MetricFamilySamples($data);
         }
         return $histograms;
     }

--- a/src/Prometheus/Storage/APC.php
+++ b/src/Prometheus/Storage/APC.php
@@ -63,11 +63,16 @@ class APC implements Adapter
 
     public function updateGauge(array $data)
     {
-        $new = apc_add($this->valueKey($data), 0);
-        if ($new) {
+        if ($data['command'] == Adapter::COMMAND_SET) {
+            apc_store($this->valueKey($data), $this->toInteger($data['value']));
             apc_store($this->metaKey($data), json_encode($this->metaData($data)));
+        } else {
+            $new = apc_add($this->valueKey($data), 0);
+            if ($new) {
+                apc_store($this->metaKey($data), json_encode($this->metaData($data)));
+            }
+            apc_inc($this->valueKey($data), $this->toInteger($data['value']));
         }
-        apc_inc($this->valueKey($data), $this->toInteger($data['value']));
     }
 
     public function updateCounter(array $data)

--- a/src/Prometheus/Storage/APC.php
+++ b/src/Prometheus/Storage/APC.php
@@ -180,7 +180,7 @@ class APC implements Adapter
                     'name' => $metaData['name'],
                     'labelNames' => array(),
                     'labelValues' => json_decode($labelValues),
-                    'value' => $value['value'] / self::PRECISION_FACTOR
+                    'value' => $this->fromInteger($value['value'])
                 );
             }
 
@@ -255,7 +255,7 @@ class APC implements Adapter
                     'name' => $metaData['name'] . '_sum',
                     'labelNames' => array(),
                     'labelValues' => $decodedLabelValues,
-                    'value' => $histogramBuckets[$labelValues]['sum'] / self::PRECISION_FACTOR
+                    'value' => $this->fromInteger($histogramBuckets[$labelValues]['sum'])
                 );
 
                 $histograms[] = new MetricFamilySamples($data);
@@ -272,6 +272,15 @@ class APC implements Adapter
     private function toInteger($val)
     {
         return (int)($val * self::PRECISION_FACTOR);
+    }
+
+    /**
+     * @param mixed $val
+     * @return int
+     */
+    private function fromInteger($val)
+    {
+        return $val / self::PRECISION_FACTOR;
     }
 
     private function sortSamples(array &$samples)

--- a/src/Prometheus/Storage/APC.php
+++ b/src/Prometheus/Storage/APC.php
@@ -148,6 +148,7 @@ class APC implements Adapter
                     'value' => $value['value']
                 );
             }
+            $this->sortSamples($data['samples']);
             $counters[] = new MetricFamilySamples($data);
         }
         return $counters;
@@ -177,6 +178,8 @@ class APC implements Adapter
                     'value' => $value['value'] / self::PRECISION_FACTOR
                 );
             }
+
+            $this->sortSamples($data['samples']);
             $gauges[] = new MetricFamilySamples($data);
         }
         return $gauges;
@@ -264,5 +267,12 @@ class APC implements Adapter
     private function toInteger($val)
     {
         return (int)($val * self::PRECISION_FACTOR);
+    }
+
+    private function sortSamples(array &$samples)
+    {
+        usort($samples, function($a, $b){
+            return strcmp(implode("", $a['labelValues']), implode("", $b['labelValues']));
+        });
     }
 }

--- a/tests/Test/BlackBoxTest.php
+++ b/tests/Test/BlackBoxTest.php
@@ -12,10 +12,16 @@ class BlackBoxTest extends PHPUnit_Framework_TestCase
      */
     private $client;
 
+    /**
+     * @var string
+     */
+    private $adapter;
+
     public function setUp()
     {
-        $this->client = new Client(['base_uri' => 'http://localhost:8080/']);
-        $this->client->get('/examples/flush_redis.php');
+        $this->adapter = getenv('ADAPTER');
+        $this->client = new Client(['base_uri' => 'http://192.168.59.100:8080/']);
+        $this->client->get('/examples/flush_adapter.php?adapter=' . $this->adapter);
     }
 
     /**
@@ -25,9 +31,9 @@ class BlackBoxTest extends PHPUnit_Framework_TestCase
     {
         $start = microtime(true);
         $promises = [
-            $this->client->getAsync('/examples/some_gauge.php?c=0'),
-            $this->client->getAsync('/examples/some_gauge.php?c=1'),
-            $this->client->getAsync('/examples/some_gauge.php?c=2'),
+            $this->client->getAsync('/examples/some_gauge.php?c=0&adapter=' . $this->adapter),
+            $this->client->getAsync('/examples/some_gauge.php?c=1&adapter=' . $this->adapter),
+            $this->client->getAsync('/examples/some_gauge.php?c=2&adapter=' . $this->adapter),
 
         ];
 
@@ -35,7 +41,7 @@ class BlackBoxTest extends PHPUnit_Framework_TestCase
         $end = microtime(true);
         echo "\ntime: " . ($end - $start) . "\n";
 
-        $metricsResult = $this->client->get('/examples/metrics.php');
+        $metricsResult = $this->client->get('/examples/metrics.php?adapter=' . $this->adapter);
         $body = (string)$metricsResult->getBody();
         echo "\nbody: " . $body . "\n";
         $this->assertThat(
@@ -57,7 +63,7 @@ class BlackBoxTest extends PHPUnit_Framework_TestCase
         $promises = [];
         $sum = 0;
         for ($i = 0; $i < 1100; $i++) {
-            $promises[] =  $this->client->getAsync('/examples/some_counter.php?c=' . $i);
+            $promises[] =  $this->client->getAsync('/examples/some_counter.php?c=' . $i . '&adapter=' . $this->adapter);
             $sum += $i;
         }
 
@@ -65,7 +71,7 @@ class BlackBoxTest extends PHPUnit_Framework_TestCase
         $end = microtime(true);
         echo "\ntime: " . ($end - $start) . "\n";
 
-        $metricsResult = $this->client->get('/examples/metrics.php');
+        $metricsResult = $this->client->get('/examples/metrics.php?adapter=' . $this->adapter);
         $body = (string)$metricsResult->getBody();
 
         $this->assertThat($body, $this->stringContains('test_some_counter{type="blue"} ' . $sum));
@@ -78,23 +84,23 @@ class BlackBoxTest extends PHPUnit_Framework_TestCase
     {
         $start = microtime(true);
         $promises = [
-            $this->client->getAsync('/examples/some_histogram.php?c=0'),
-            $this->client->getAsync('/examples/some_histogram.php?c=1'),
-            $this->client->getAsync('/examples/some_histogram.php?c=2'),
-            $this->client->getAsync('/examples/some_histogram.php?c=3'),
-            $this->client->getAsync('/examples/some_histogram.php?c=4'),
-            $this->client->getAsync('/examples/some_histogram.php?c=5'),
-            $this->client->getAsync('/examples/some_histogram.php?c=6'),
-            $this->client->getAsync('/examples/some_histogram.php?c=7'),
-            $this->client->getAsync('/examples/some_histogram.php?c=8'),
-            $this->client->getAsync('/examples/some_histogram.php?c=9'),
+            $this->client->getAsync('/examples/some_histogram.php?c=0&adapter=' . $this->adapter),
+            $this->client->getAsync('/examples/some_histogram.php?c=1&adapter=' . $this->adapter),
+            $this->client->getAsync('/examples/some_histogram.php?c=2&adapter=' . $this->adapter),
+            $this->client->getAsync('/examples/some_histogram.php?c=3&adapter=' . $this->adapter),
+            $this->client->getAsync('/examples/some_histogram.php?c=4&adapter=' . $this->adapter),
+            $this->client->getAsync('/examples/some_histogram.php?c=5&adapter=' . $this->adapter),
+            $this->client->getAsync('/examples/some_histogram.php?c=6&adapter=' . $this->adapter),
+            $this->client->getAsync('/examples/some_histogram.php?c=7&adapter=' . $this->adapter),
+            $this->client->getAsync('/examples/some_histogram.php?c=8&adapter=' . $this->adapter),
+            $this->client->getAsync('/examples/some_histogram.php?c=9&adapter=' . $this->adapter),
         ];
 
         Promise\settle($promises)->wait();
         $end = microtime(true);
         echo "\ntime: " . ($end - $start) . "\n";
 
-        $metricsResult = $this->client->get('/examples/metrics.php');
+        $metricsResult = $this->client->get('/examples/metrics.php?adapter=' . $this->adapter);
         $body = (string)$metricsResult->getBody();
 
         $this->assertThat($body, $this->stringContains(<<<EOF

--- a/tests/Test/Prometheus/APC/CollectorRegistryTest.php
+++ b/tests/Test/Prometheus/APC/CollectorRegistryTest.php
@@ -1,0 +1,16 @@
+<?php
+
+
+namespace Test\Prometheus\APC;
+
+use Prometheus\Storage\APC;
+use Test\Prometheus\AbstractCollectorRegistryTest;
+
+class CollectorRegistryTest extends AbstractCollectorRegistryTest
+{
+    public function configureAdapter()
+    {
+        $this->adapter = new APC();
+        $this->adapter->flushAPC();
+    }
+}

--- a/tests/Test/Prometheus/APC/CounterTest.php
+++ b/tests/Test/Prometheus/APC/CounterTest.php
@@ -1,0 +1,20 @@
+<?php
+
+
+namespace Test\Prometheus\APC;
+
+use Prometheus\Storage\APC;
+use Test\Prometheus\AbstractCounterTest;
+
+/**
+ * See https://prometheus.io/docs/instrumenting/exposition_formats/
+ */
+class CounterTest extends AbstractCounterTest
+{
+
+    public function configureAdapter()
+    {
+        $this->adapter = new APC();
+        $this->adapter->flushAPC();
+    }
+}

--- a/tests/Test/Prometheus/APC/GaugeTest.php
+++ b/tests/Test/Prometheus/APC/GaugeTest.php
@@ -1,0 +1,20 @@
+<?php
+
+
+namespace Test\Prometheus\APC;
+
+use Prometheus\Storage\APC;
+use Test\Prometheus\AbstractGaugeTest;
+
+/**
+ * See https://prometheus.io/docs/instrumenting/exposition_formats/
+ */
+class GaugeTest extends AbstractGaugeTest
+{
+
+    public function configureAdapter()
+    {
+        $this->adapter = new APC();
+        $this->adapter->flushAPC();
+    }
+}

--- a/tests/Test/Prometheus/APC/HistogramTest.php
+++ b/tests/Test/Prometheus/APC/HistogramTest.php
@@ -1,0 +1,21 @@
+<?php
+
+
+namespace Test\Prometheus\APC;
+
+use Prometheus\Storage\APC;
+use Test\Prometheus\AbstractHistogramTest;
+
+/**
+ * See https://prometheus.io/docs/instrumenting/exposition_formats/
+ */
+class HistogramTest extends AbstractHistogramTest
+{
+
+    public function configureAdapter()
+    {
+        $this->adapter = new APC();
+        $this->adapter->flushAPC();
+    }
+}
+

--- a/tests/Test/Prometheus/AbstractCollectorRegistryTest.php
+++ b/tests/Test/Prometheus/AbstractCollectorRegistryTest.php
@@ -38,8 +38,10 @@ abstract class AbstractCollectorRegistryTest extends PHPUnit_Framework_TestCase
         $registry = new CollectorRegistry($this->adapter);
 
         $g = $registry->registerGauge('test', 'some_metric', 'this is for testing', array('foo'));
-        $g->set(32, array('lalal'));
-        $g->set(35, array('lalab'));
+        $g->set(35, array('bbb'));
+        $g->set(35, array('ddd'));
+        $g->set(35, array('aaa'));
+        $g->set(35, array('ccc'));
 
 
         $registry = new CollectorRegistry($this->adapter);
@@ -48,8 +50,10 @@ abstract class AbstractCollectorRegistryTest extends PHPUnit_Framework_TestCase
             $this->equalTo(<<<EOF
 # HELP test_some_metric this is for testing
 # TYPE test_some_metric gauge
-test_some_metric{foo="lalab"} 35
-test_some_metric{foo="lalal"} 32
+test_some_metric{foo="aaa"} 35
+test_some_metric{foo="bbb"} 35
+test_some_metric{foo="ccc"} 35
+test_some_metric{foo="ddd"} 35
 
 EOF
             )

--- a/tests/Test/Prometheus/AbstractCollectorRegistryTest.php
+++ b/tests/Test/Prometheus/AbstractCollectorRegistryTest.php
@@ -33,7 +33,7 @@ abstract class AbstractCollectorRegistryTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function itShouldSaveGaugesInRedis()
+    public function itShouldSaveGauges()
     {
         $registry = new CollectorRegistry($this->adapter);
 
@@ -59,7 +59,7 @@ EOF
     /**
      * @test
      */
-    public function itShouldSaveCountersInRedis()
+    public function itShouldSaveCounters()
     {
         $registry = new CollectorRegistry($this->adapter);
         $metric = $registry->registerCounter('test', 'some_metric', 'this is for testing', array('foo', 'bar'));
@@ -84,7 +84,7 @@ EOF
     /**
      * @test
      */
-    public function itShouldSaveHistogramsInRedis()
+    public function itShouldSaveHistograms()
     {
         $registry = new CollectorRegistry($this->adapter);
         $metric = $registry->registerHistogram('test', 'some_metric', 'this is for testing', array('foo', 'bar'), array(0.1, 1, 5, 10));

--- a/tests/Test/Prometheus/AbstractGaugeTest.php
+++ b/tests/Test/Prometheus/AbstractGaugeTest.php
@@ -259,6 +259,39 @@ abstract class AbstractGaugeTest extends PHPUnit_Framework_TestCase
 
     /**
      * @test
+     */
+    public function itShouldOverwriteWhenSettingTwice()
+    {
+        $gauge = new Gauge($this->adapter, 'test', 'some_metric', 'this is for testing', array('foo', 'bar'));
+        $gauge->set(123, array('lalal', 'lululu'));
+        $gauge->set(321, array('lalal', 'lululu'));
+        $this->assertThat(
+            $this->adapter->collect(),
+            $this->equalTo(
+                array(
+                    new MetricFamilySamples(
+                        array(
+                            'name' => 'test_some_metric',
+                            'help' => 'this is for testing',
+                            'type' => Gauge::TYPE,
+                            'labelNames' => array('foo', 'bar'),
+                            'samples' => array(
+                                array(
+                                    'name' => 'test_some_metric',
+                                    'labelNames' => array(),
+                                    'labelValues' => array('lalal', 'lululu'),
+                                    'value' => 321,
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    /**
+     * @test
      * @expectedException \InvalidArgumentException
      */
     public function itShouldRejectInvalidMetricsNames()

--- a/tests/Test/Prometheus/AbstractGaugeTest.php
+++ b/tests/Test/Prometheus/AbstractGaugeTest.php
@@ -94,6 +94,40 @@ abstract class AbstractGaugeTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function itShouldAllowSetWithAFloatValue()
+    {
+        $gauge = new Gauge($this->adapter, 'test', 'some_metric', 'this is for testing');
+        $gauge->set(123.5);
+        $this->assertThat(
+            $this->adapter->collect(),
+            $this->equalTo(
+                array(
+                    new MetricFamilySamples(
+                        array(
+                            'name' => 'test_some_metric',
+                            'help' => 'this is for testing',
+                            'type' => Gauge::TYPE,
+                            'labelNames' => array(),
+                            'samples' => array(
+                                array(
+                                    'name' => 'test_some_metric',
+                                    'labelNames' => array(),
+                                    'labelValues' => array(),
+                                    'value' => 123.5,
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        );
+        $this->assertThat($gauge->getHelp(), $this->equalTo('this is for testing'));
+        $this->assertThat($gauge->getType(), $this->equalTo(Gauge::TYPE));
+    }
+
+    /**
+     * @test
+     */
     public function itShouldIncrementAValue()
     {
         $gauge = new Gauge($this->adapter, 'test', 'some_metric', 'this is for testing', array('foo', 'bar'));
@@ -127,7 +161,73 @@ abstract class AbstractGaugeTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function itShouldIncrementWithFloatValue()
+    {
+        $gauge = new Gauge($this->adapter, 'test', 'some_metric', 'this is for testing', array('foo', 'bar'));
+        $gauge->inc(array('lalal', 'lululu'));
+        $gauge->incBy(123.5, array('lalal', 'lululu'));
+        $this->assertThat(
+            $this->adapter->collect(),
+            $this->equalTo(
+                array(
+                    new MetricFamilySamples(
+                        array(
+                            'name' => 'test_some_metric',
+                            'help' => 'this is for testing',
+                            'type' => Gauge::TYPE,
+                            'labelNames' => array('foo', 'bar'),
+                            'samples' => array(
+                                array(
+                                    'name' => 'test_some_metric',
+                                    'labelNames' => array(),
+                                    'labelValues' => array('lalal', 'lululu'),
+                                    'value' => 124.5,
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    /**
+     * @test
+     */
     public function itShouldDecrementAValue()
+    {
+        $gauge = new Gauge($this->adapter, 'test', 'some_metric', 'this is for testing', array('foo', 'bar'));
+        $gauge->dec(array('lalal', 'lululu'));
+        $gauge->decBy(123, array('lalal', 'lululu'));
+        $this->assertThat(
+            $this->adapter->collect(),
+            $this->equalTo(
+                array(
+                    new MetricFamilySamples(
+                        array(
+                            'name' => 'test_some_metric',
+                            'help' => 'this is for testing',
+                            'type' => Gauge::TYPE,
+                            'labelNames' => array('foo', 'bar'),
+                            'samples' => array(
+                                array(
+                                    'name' => 'test_some_metric',
+                                    'labelNames' => array(),
+                                    'labelValues' => array('lalal', 'lululu'),
+                                    'value' => -124,
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldDecrementWithFloatValue()
     {
         $gauge = new Gauge($this->adapter, 'test', 'some_metric', 'this is for testing', array('foo', 'bar'));
         $gauge->dec(array('lalal', 'lululu'));

--- a/tests/Test/Prometheus/Redis/CollectorRegistryTest.php
+++ b/tests/Test/Prometheus/Redis/CollectorRegistryTest.php
@@ -1,0 +1,16 @@
+<?php
+
+
+namespace Test\Prometheus\Redis;
+
+use Prometheus\Storage\Redis;
+use Test\Prometheus\AbstractCollectorRegistryTest;
+
+class CollectorRegistryTest extends AbstractCollectorRegistryTest
+{
+    public function configureAdapter()
+    {
+        $this->adapter = new Redis(array('host' => REDIS_HOST));
+        $this->adapter->flushRedis();
+    }
+}

--- a/tests/Test/Prometheus/Redis/CounterTest.php
+++ b/tests/Test/Prometheus/Redis/CounterTest.php
@@ -1,0 +1,20 @@
+<?php
+
+
+namespace Test\Prometheus\Redis;
+
+use Prometheus\Storage\Redis;
+use Test\Prometheus\AbstractCounterTest;
+
+/**
+ * See https://prometheus.io/docs/instrumenting/exposition_formats/
+ */
+class CounterTest extends AbstractCounterTest
+{
+
+    public function configureAdapter()
+    {
+        $this->adapter = new Redis(array('host' => REDIS_HOST));
+        $this->adapter->flushRedis();
+    }
+}

--- a/tests/Test/Prometheus/Redis/GaugeTest.php
+++ b/tests/Test/Prometheus/Redis/GaugeTest.php
@@ -1,0 +1,20 @@
+<?php
+
+
+namespace Test\Prometheus\Redis;
+
+use Prometheus\Storage\Redis;
+use Test\Prometheus\AbstractGaugeTest;
+
+/**
+ * See https://prometheus.io/docs/instrumenting/exposition_formats/
+ */
+class GaugeTest extends AbstractGaugeTest
+{
+
+    public function configureAdapter()
+    {
+        $this->adapter = new Redis(array('host' => REDIS_HOST));
+        $this->adapter->flushRedis();
+    }
+}

--- a/tests/Test/Prometheus/Redis/HistogramTest.php
+++ b/tests/Test/Prometheus/Redis/HistogramTest.php
@@ -1,0 +1,20 @@
+<?php
+
+
+namespace Test\Prometheus\Redis;
+
+use Prometheus\Storage\Redis;
+use Test\Prometheus\AbstractHistogramTest;
+
+/**
+ * See https://prometheus.io/docs/instrumenting/exposition_formats/
+ */
+class HistogramTest extends AbstractHistogramTest
+{
+
+    public function configureAdapter()
+    {
+        $this->adapter = new Redis(array('host' => REDIS_HOST));
+        $this->adapter->flushRedis();
+    }
+}


### PR DESCRIPTION
This PR enables to collect metrics w/o any external dependencies, just by relying on [APCu](http://php.net/manual/en/book.apcu.php).
In order to get it to work with APC (which only allow for atomic operations to work on integers) we use the same [technique](https://github.com/prometheus/client_golang/blob/66058aac3a83021948e5fb12f1f408ff556b9037/prometheus/value.go#L92-L98) as in the Golang client.