### PR TITLE
Require PHP 5.5 instead of 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 php:
-  - 5.6
+  - 5.5
 
 services:
   - redis-server

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Also look at the [examples](examples).
 
 ### Dependencies
 
-* PHP 5.6
+* PHP 5.5
 * PHP Redis extension
 * PHP APCu extension
 * [Composer](https://getcomposer.org/doc/00-intro.md#installation-linux-unix-osx)

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=5.6.3",
+        "php": ">=5.5",
         "guzzlehttp/guzzle": "^6.2"
     },
     "require-dev": {


### PR DESCRIPTION
We are currently using this library in production using PHP 5.5 and everything is working fine. I did a quick scan and I couldn't find any 5.6-only syntax/features. 

If you know about any possible incompatibility issues, ping me and I will gladly fix. If not, please merge :-)