### PR TITLE
Remove Redis Requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,16 @@ While the former needs a separate binary running, the latter just needs the [APC
 
 A simple counter:
 ```php
-\Prometheus\CollectorRegistry::getDefault()
+$adapter = new Prometheus\Storage\APC();
+$registry = (new CollectorRegistry($adapter))
     ->getOrRegisterCounter('', 'some_quick_counter', 'just a quick measurement')
     ->inc();
 ```
 
 Write some enhanced metrics:
 ```php
-$registry = \Prometheus\CollectorRegistry::getDefault();
+$adapter = new Prometheus\Storage\APC();
+$registry = new CollectorRegistry($adapter);
 
 $counter = $registry->getOrRegisterCounter('test', 'some_counter', 'it increases', ['type']);
 $counter->incBy(3, ['blue']);
@@ -39,7 +41,8 @@ $histogram->observe(3.5, ['blue']);
 
 Manually register and retrieve metrics (these steps are combined in the `getOrRegister...` methods):
 ```php
-$registry = \Prometheus\CollectorRegistry::getDefault();
+$adapter = new Prometheus\Storage\APC();
+$registry = new CollectorRegistry($adapter);
 
 $counterA = $registry->registerCounter('test', 'some_counter', 'it increases', ['type']);
 $counterA->incBy(3, ['blue']);
@@ -51,8 +54,8 @@ $counterB->incBy(2, ['red']);
 
 Expose the metrics:
 ```php
-$registry = \Prometheus\CollectorRegistry::getDefault();
-$registry = CollectorRegistry::getDefault();
+$adapter = new Prometheus\Storage\APC();
+$registry = new CollectorRegistry($adapter);
 
 $renderer = new RenderTextFormat();
 $result = $renderer->render($registry->getMetricFamilySamples());

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=5.6.3",
+        "php": ">=5.5",
         "guzzlehttp/guzzle": "^6.2"
     },
     "require-dev": {

--- a/src/Prometheus/CollectorRegistry.php
+++ b/src/Prometheus/CollectorRegistry.php
@@ -7,15 +7,9 @@ namespace Prometheus;
 use Prometheus\Exception\MetricNotFoundException;
 use Prometheus\Exception\MetricsRegistrationException;
 use Prometheus\Storage\Adapter;
-use Prometheus\Storage\Redis;
 
 class CollectorRegistry
 {
-    /**
-     * @var CollectorRegistry
-     */
-    private static $defaultRegistry;
-
     /**
      * @var Adapter
      */
@@ -33,20 +27,9 @@ class CollectorRegistry
      */
     private $histograms = array();
 
-    public function __construct(Adapter $redisAdapter)
+    public function __construct(Adapter $adapter)
     {
-        $this->storageAdapter = $redisAdapter;
-    }
-
-    /**
-     * @return CollectorRegistry
-     */
-    public static function getDefault()
-    {
-        if (!self::$defaultRegistry) {
-            return self::$defaultRegistry = new static(new Redis());
-        }
-        return self::$defaultRegistry;
+        $this->storageAdapter = $adapter;
     }
 
     /**

--- a/src/Prometheus/Storage/APC.php
+++ b/src/Prometheus/Storage/APC.php
@@ -271,7 +271,7 @@ class APC implements Adapter
      */
     private function toInteger($val)
     {
-        return unpack('Q', pack('d', $val))[1];
+        return intval($val);
     }
 
     /**
@@ -280,7 +280,7 @@ class APC implements Adapter
      */
     private function fromInteger($val)
     {
-        return unpack('d', pack('Q', $val))[1];
+        return intval($val);
     }
 
     private function sortSamples(array &$samples)

--- a/src/Prometheus/Storage/APC.php
+++ b/src/Prometheus/Storage/APC.php
@@ -1,10 +1,10 @@
 <?php
 
-
 namespace Prometheus\Storage;
 
-
 use Prometheus\MetricFamilySamples;
+
+if (extension_loaded('apcu') || extension_loaded('apc')) {
 
 class APC implements Adapter
 {
@@ -290,3 +290,5 @@ class APC implements Adapter
         });
     }
 }
+
+} // End extension_loaded check

--- a/src/Prometheus/Storage/APC.php
+++ b/src/Prometheus/Storage/APC.php
@@ -4,8 +4,6 @@ namespace Prometheus\Storage;
 
 use Prometheus\MetricFamilySamples;
 
-if (extension_loaded('apcu') || extension_loaded('apc')) {
-
 class APC implements Adapter
 {
     const PROMETHEUS_PREFIX = 'prom';
@@ -291,4 +289,3 @@ class APC implements Adapter
     }
 }
 
-} // End extension_loaded check

--- a/src/Prometheus/Storage/Redis.php
+++ b/src/Prometheus/Storage/Redis.php
@@ -9,8 +9,6 @@ use Prometheus\Gauge;
 use Prometheus\Histogram;
 use Prometheus\MetricFamilySamples;
 
-if (extension_loaded('redis')) {
-
 class Redis implements Adapter
 {
     const PROMETHEUS_PREFIX = 'PROMETHEUS_';
@@ -343,4 +341,3 @@ LUA
 
 }
 
-} // End extension_loaded check

--- a/src/Prometheus/Storage/Redis.php
+++ b/src/Prometheus/Storage/Redis.php
@@ -9,6 +9,8 @@ use Prometheus\Gauge;
 use Prometheus\Histogram;
 use Prometheus\MetricFamilySamples;
 
+if (extension_loaded('redis')) {
+
 class Redis implements Adapter
 {
     const PROMETHEUS_PREFIX = 'PROMETHEUS_';
@@ -340,3 +342,5 @@ LUA
     }
 
 }
+
+} // End extension_loaded check


### PR DESCRIPTION
I don't feel like you should have to install redis to use this library.
This makes it so that you can use the library without having fatal errors
thrown due to a missing optional dependency like redis.