### PR TITLE
Let users change Redis key prefix

### DIFF
--- a/src/Prometheus/Storage/Redis.php
+++ b/src/Prometheus/Storage/Redis.php
@@ -11,10 +11,10 @@ use Prometheus\MetricFamilySamples;
 
 class Redis implements Adapter
 {
-    const PROMETHEUS_PREFIX = 'PROMETHEUS_';
     const PROMETHEUS_METRIC_KEYS_SUFFIX = '_METRIC_KEYS';
 
     private static $defaultOptions = array();
+    private static $prefix = 'PROMETHEUS_';
 
     private $options;
     private $redis;
@@ -49,6 +49,11 @@ class Redis implements Adapter
     public static function setDefaultOptions(array $options)
     {
         self::$defaultOptions = array_merge(self::$defaultOptions, $options);
+    }
+
+    public static function setPrefix($prefix)
+    {
+        self::$prefix = $prefix;
     }
 
     public function flushRedis()
@@ -118,7 +123,7 @@ LUA
                 $this->toMetricKey($data),
                 json_encode(array('b' => 'sum', 'labelValues' => $data['labelValues'])),
                 json_encode(array('b' => $bucketToIncrease, 'labelValues' => $data['labelValues'])),
-                self::PROMETHEUS_PREFIX . Histogram::TYPE . self::PROMETHEUS_METRIC_KEYS_SUFFIX,
+                self::$prefix . Histogram::TYPE . self::PROMETHEUS_METRIC_KEYS_SUFFIX,
                 $data['value'],
                 json_encode($metaData),
             ),
@@ -152,7 +157,7 @@ LUA
             array(
                 $this->toMetricKey($data),
                 $this->getRedisCommand($data['command']),
-                self::PROMETHEUS_PREFIX . Gauge::TYPE . self::PROMETHEUS_METRIC_KEYS_SUFFIX,
+                self::$prefix . Gauge::TYPE . self::PROMETHEUS_METRIC_KEYS_SUFFIX,
                 json_encode($data['labelValues']),
                 $data['value'],
                 json_encode($metaData),
@@ -180,7 +185,7 @@ LUA
             array(
                 $this->toMetricKey($data),
                 $this->getRedisCommand($data['command']),
-                self::PROMETHEUS_PREFIX . Counter::TYPE . self::PROMETHEUS_METRIC_KEYS_SUFFIX,
+                self::$prefix . Counter::TYPE . self::PROMETHEUS_METRIC_KEYS_SUFFIX,
                 json_encode($data['labelValues']),
                 $data['value'],
                 json_encode($metaData),
@@ -192,7 +197,7 @@ LUA
 
     private function collectHistograms()
     {
-        $keys = $this->redis->sMembers(self::PROMETHEUS_PREFIX . Histogram::TYPE . self::PROMETHEUS_METRIC_KEYS_SUFFIX);
+        $keys = $this->redis->sMembers(self::$prefix . Histogram::TYPE . self::PROMETHEUS_METRIC_KEYS_SUFFIX);
         sort($keys);
         $histograms = array();
         foreach ($keys as $key) {
@@ -266,7 +271,7 @@ LUA
 
     private function collectGauges()
     {
-        $keys = $this->redis->sMembers(self::PROMETHEUS_PREFIX . Gauge::TYPE . self::PROMETHEUS_METRIC_KEYS_SUFFIX);
+        $keys = $this->redis->sMembers(self::$prefix . Gauge::TYPE . self::PROMETHEUS_METRIC_KEYS_SUFFIX);
         sort($keys);
         $gauges = array();
         foreach ($keys as $key) {
@@ -292,7 +297,7 @@ LUA
 
     private function collectCounters()
     {
-        $keys = $this->redis->sMembers(self::PROMETHEUS_PREFIX . Counter::TYPE . self::PROMETHEUS_METRIC_KEYS_SUFFIX);
+        $keys = $this->redis->sMembers(self::$prefix . Counter::TYPE . self::PROMETHEUS_METRIC_KEYS_SUFFIX);
         sort($keys);
         $counters = array();
         foreach ($keys as $key) {
@@ -336,7 +341,7 @@ LUA
      */
     private function toMetricKey(array $data)
     {
-        return implode(':', array(self::PROMETHEUS_PREFIX, $data['type'], $data['name']));
+        return implode(':', array(self::$prefix, $data['type'], $data['name']));
     }
 
 }


### PR DESCRIPTION
This pull request adds Prometheus\Storage\Redis::setPrefix to set a custom key prefix, to separate multiple installations on the same Redis server.