### PR TITLE
Correct autoloading for tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,5 +26,10 @@
             "Prometheus\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-0": {
+            "Test\\Prometheus\\": "tests/"
+        }
+    },
     "license": "Apache-2.0"
 }


### PR DESCRIPTION
Tests cannot be autoloaded correctly as they do not reside in the `Prometheus\` namespace.
This PR will add a `autoload-dev` directive for the `Test\Prometheus\` namespace so that all tests can be picked up correctly.