### PR TITLE
False positive tests for invalid histogram label name

### DIFF
--- a/src/Prometheus/Histogram.php
+++ b/src/Prometheus/Histogram.php
@@ -39,8 +39,8 @@ class Histogram extends Collector
                 );
             }
         }
-        foreach ($buckets as $bucket) {
-            if ($bucket == 'le') {
+        foreach ($labels as $label) {
+            if ($label === 'le') {
                 throw new \InvalidArgumentException("Histogram cannot have a label named 'le'.");
             }
         }

--- a/tests/Test/Prometheus/AbstractHistogramTest.php
+++ b/tests/Test/Prometheus/AbstractHistogramTest.php
@@ -374,6 +374,7 @@ abstract class AbstractHistogramTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Histogram buckets must be in increasing order
      */
     public function itShouldThrowAnExceptionWhenTheBucketSizesAreNotIncreasing()
     {
@@ -383,6 +384,7 @@ abstract class AbstractHistogramTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Histogram must have at least one bucket
      */
     public function itShouldThrowAnExceptionWhenThereIsLessThanOneBucket()
     {
@@ -392,15 +394,17 @@ abstract class AbstractHistogramTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Histogram cannot have a label named
      */
     public function itShouldThrowAnExceptionWhenThereIsALabelNamedLe()
     {
-        new Histogram($this->adapter, 'test', 'some_metric', 'this is for testing', array('le'), array());
+        new Histogram($this->adapter, 'test', 'some_metric', 'this is for testing', array('le'), array(1));
     }
 
     /**
      * @test
      * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Invalid metric name
      */
     public function itShouldRejectInvalidMetricsNames()
     {
@@ -410,6 +414,7 @@ abstract class AbstractHistogramTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Invalid label name
      */
     public function itShouldRejectInvalidLabelNames()
     {


### PR DESCRIPTION
The tests are green incorrectly as the tests only check for `\InvalidArgumentException` but all checks throw this exception. As such the `itShouldThrowAnExceptionWhenThereIsALabelNamedLe` test is incorrectly green as the labels aren't checked (the bucket "names" are).

This PR corrects the check for the Histogram and modifies all tests for Histogram to also validate the error message.