### PR TITLE
Add Redis auth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Change the Redis options (the example shows the defaults):
     [
         'host' => '127.0.0.1',
         'port' => 6379,
+        'password' => null,
         'timeout' => 0.1, // in seconds
         'read_timeout' => 10, // in seconds
         'persistent_connections' => false

--- a/src/Prometheus/Storage/Redis.php
+++ b/src/Prometheus/Storage/Redis.php
@@ -38,6 +38,9 @@ class Redis implements Adapter
         if (!isset(self::$defaultOptions['persistent_connections'])) {
             self::$defaultOptions['persistent_connections'] = false;
         }
+        if (!isset(self::$defaultOptions['password'])) {
+            self::$defaultOptions['password'] = null;
+        }
 
         $this->options = array_merge(self::$defaultOptions, $options);
         $this->redis = new \Redis();
@@ -90,6 +93,9 @@ class Redis implements Adapter
                 @$this->redis->pconnect($this->options['host'], $this->options['port'], $this->options['timeout']);
             } else {
                 @$this->redis->connect($this->options['host'], $this->options['port'], $this->options['timeout']);
+            }
+            if ($this->options['password']) {
+                $this->redis->auth($this->options['password']);
             }
             $this->redis->setOption(\Redis::OPT_READ_TIMEOUT, $this->options['read_timeout']);
         } catch (\RedisException $e) {


### PR DESCRIPTION
Oftentimes, redis servers in production require password authentication, this PR adds a `password` field to the redis config.