### PR TITLE
Adds base64-encoding of label values to allow the usage of colons

### DIFF
--- a/tests/Test/Prometheus/AbstractCounterTest.php
+++ b/tests/Test/Prometheus/AbstractCounterTest.php
@@ -6,6 +6,8 @@ namespace Test\Prometheus;
 use PHPUnit_Framework_TestCase;
 use Prometheus\Counter;
 use Prometheus\MetricFamilySamples;
+use Prometheus\Sample;
+use Prometheus\Storage\Adapter;
 
 /**
  * See https://prometheus.io/docs/instrumenting/exposition_formats/
@@ -137,6 +139,51 @@ abstract class AbstractCounterTest extends PHPUnit_Framework_TestCase
     public function itShouldRejectInvalidLabelNames()
     {
         new Counter($this->adapter, 'test', 'some_metric', 'help', array('invalid label'));
+    }
+
+    /**
+     * @test
+     * @dataProvider labelValuesDataProvider
+     *
+     * @param mixed $value The label value
+     */
+    public function isShouldAcceptAnySequenceOfBasicLatinCharactersForLabelValues($value)
+    {
+        $label = 'foo';
+        $histogram = new Counter($this->adapter, 'test', 'some_metric', 'help', array($label));
+        $histogram->inc(array($value));
+
+        $metrics = $this->adapter->collect();
+        self::assertInternalType('array', $metrics);
+        self::assertCount(1, $metrics);
+        self::assertContainsOnlyInstancesOf(MetricFamilySamples::class, $metrics);
+
+        $metric = reset($metrics);
+        $samples = $metric->getSamples();
+        self::assertContainsOnlyInstancesOf(Sample::class, $samples);
+
+        foreach ($samples as $sample) {
+            $labels = array_combine(
+                array_merge($metric->getLabelNames(), $sample->getLabelNames()),
+                $sample->getLabelValues()
+            );
+            self::assertEquals($value, $labels[$label]);
+        }
+    }
+
+    /**
+     * @see isShouldAcceptArbitraryLabelValues
+     * @return array
+     */
+    public function labelValuesDataProvider()
+    {
+        $cases = [];
+        // Basic Latin
+        // See https://en.wikipedia.org/wiki/List_of_Unicode_characters#Basic_Latin
+        for ($i = 32; $i <= 121; $i++) {
+            $cases['ASCII code ' . $i] = array(chr($i));
+        }
+        return $cases;
     }
 
     public abstract function configureAdapter();

--- a/tests/Test/Prometheus/AbstractGaugeTest.php
+++ b/tests/Test/Prometheus/AbstractGaugeTest.php
@@ -6,6 +6,7 @@ namespace Test\Prometheus;
 use PHPUnit_Framework_TestCase;
 use Prometheus\Gauge;
 use Prometheus\MetricFamilySamples;
+use Prometheus\Sample;
 use Prometheus\Storage\Adapter;
 
 /**
@@ -306,6 +307,51 @@ abstract class AbstractGaugeTest extends PHPUnit_Framework_TestCase
     public function itShouldRejectInvalidLabelNames()
     {
         new Gauge($this->adapter, 'test', 'some_metric', 'help', array('invalid label'));
+    }
+
+    /**
+     * @test
+     * @dataProvider labelValuesDataProvider
+     *
+     * @param mixed $value The label value
+     */
+    public function isShouldAcceptAnySequenceOfBasicLatinCharactersForLabelValues($value)
+    {
+        $label = 'foo';
+        $histogram = new Gauge($this->adapter, 'test', 'some_metric', 'help', array($label));
+        $histogram->inc(array($value));
+
+        $metrics = $this->adapter->collect();
+        self::assertInternalType('array', $metrics);
+        self::assertCount(1, $metrics);
+        self::assertContainsOnlyInstancesOf(MetricFamilySamples::class, $metrics);
+
+        $metric = reset($metrics);
+        $samples = $metric->getSamples();
+        self::assertContainsOnlyInstancesOf(Sample::class, $samples);
+
+        foreach ($samples as $sample) {
+            $labels = array_combine(
+                array_merge($metric->getLabelNames(), $sample->getLabelNames()),
+                $sample->getLabelValues()
+            );
+            self::assertEquals($value, $labels[$label]);
+        }
+    }
+
+    /**
+     * @see isShouldAcceptArbitraryLabelValues
+     * @return array
+     */
+    public function labelValuesDataProvider()
+    {
+        $cases = [];
+        // Basic Latin
+        // See https://en.wikipedia.org/wiki/List_of_Unicode_characters#Basic_Latin
+        for ($i = 32; $i <= 121; $i++) {
+            $cases['ASCII code ' . $i] = array(chr($i));
+        }
+        return $cases;
     }
 
     public abstract function configureAdapter();


### PR DESCRIPTION
* **PR type:** bugfix
* **Issue:** https://github.com/Jimdo/prometheus_client_php/issues/56
* **BC breaking**: yes

# Expected behaviour
Label values can be any sequence of UTF-8 characters.

# Current behaviour
No measures are taken to ensure that the label values can be persisted without affecting the retrieval process.

# Steps to reproduce
1. Persist a metric (counter, gauge, histogram) using APC or In-Memory storage, which has a label with value `:` (semicolon).
1. Retrieve the metrics and observe PHP warnings and metrics with missing label.

```php
<?php

require __DIR__ . '/vendor/autoload.php';

//$adapter = new Prometheus\Storage\APC();
//$adapter->flushAPC();

$adapter = new Prometheus\Storage\InMemory();
$adapter->flushMemory();

$registry = new Prometheus\CollectorRegistry($adapter);

$counter = $registry->registerCounter('test', 'some_counter', 'it increases', ['type']);
$counter->incBy(1, [':']);

$renderer = new Prometheus\RenderTextFormat();
$result = $renderer->render($registry->getMetricFamilySamples());

header('Content-type: ' . Prometheus\RenderTextFormat::MIME_TYPE);
echo $result;
//Warning: array_combine(): Both parameters should have an equal number of elements in ///var/www/html/src/Prometheus/RenderTextFormat.php on line 39
//
//Warning: Invalid argument supplied for foreach() in ///var/www/html/src/Prometheus/RenderTextFormat.php on line 40
//
//Warning: Cannot modify header information - headers already sent by (output started at ///var/www/html/src/Prometheus/RenderTextFormat.php:39) in /var/www/html/test.php on line 19
//# HELP test_some_counter it increases
//# TYPE test_some_counter counter
//test_some_counter{} 1
``` 

# Proposed implementation
Suitable escaping strategy must be used, depending on the storage implementation. JSON-encoding is not enough to escape colons. Base64-encoding the already JSON-encoded values will make the string safe to persist when using APC and in-memory storage.

# Unresolved issues
* This PR adds support for a subset of UTF-8 - [Basic Latin](https://en.wikipedia.org/wiki/List_of_Unicode_characters#Basic_Latin). Full support for UTF-8 is still not possible using JSON-encoding and base64-encoding.
* BC break of the label values for existing records.