### PR TITLE
Add APCu Adapter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 php:
   - 5.6
+  - 7.0
 
 services:
   - redis-server
@@ -8,7 +9,8 @@ services:
 before_script:
   - echo "apc.enabled = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - echo "apc.enable_cli = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-  - echo "extension = apcu.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+  - if [[ $TRAVIS_PHP_VERSION = 5.* ]]; then echo yes | pecl install -f apcu-4.0.11; fi
+  - if [[ $TRAVIS_PHP_VERSION = 7.* ]]; then echo yes | pecl install -f apcu-5.1.5; fi
   - echo "extension = redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - composer self-update
   - composer install --no-interaction --prefer-source --dev

--- a/src/Prometheus/Storage/APCu.php
+++ b/src/Prometheus/Storage/APCu.php
@@ -1,0 +1,310 @@
+<?php
+
+
+namespace Prometheus\Storage;
+
+
+use APCUIterator;
+use function class_exists;
+use Prometheus\MetricFamilySamples;
+use RuntimeException;
+
+class APCu implements Adapter
+{
+    const PROMETHEUS_PREFIX = 'prom';
+
+    public function __construct()
+    {
+        if (!extension_loaded('apcu')) {
+            throw new RuntimeException(
+                'The `apcu` extension was not found, please use the APC adapter for earlier PHP versions'
+            );
+        }
+
+        if (!class_exists(APCUIterator::class)) {
+            throw new RuntimeException(
+                'The `apcu` extension version should be 5.0+, please use the APC adapter for earlier versions'
+            );
+        }
+    }
+
+    /**
+     * @return MetricFamilySamples[]
+     */
+    public function collect()
+    {
+        $metrics = $this->collectHistograms();
+        $metrics = array_merge($metrics, $this->collectGauges());
+        $metrics = array_merge($metrics, $this->collectCounters());
+        return $metrics;
+    }
+
+    public function updateHistogram(array $data)
+    {
+        // Initialize the sum
+        $sumKey = $this->histogramBucketValueKey($data, 'sum');
+        $new = apcu_add($sumKey, $this->toInteger(0));
+
+        // If sum does not exist, assume a new histogram and store the metadata
+        if ($new) {
+            apcu_store($this->metaKey($data), json_encode($this->metaData($data)));
+        }
+
+        // Atomically increment the sum
+        // Taken from https://github.com/prometheus/client_golang/blob/66058aac3a83021948e5fb12f1f408ff556b9037/prometheus/value.go#L91
+        $done = false;
+        while (!$done) {
+            $old = apcu_fetch($sumKey);
+            $done = apcu_cas($sumKey, $old, $this->toInteger($this->fromInteger($old) + $data['value']));
+        }
+
+        // Figure out in which bucket the observation belongs
+        $bucketToIncrease = '+Inf';
+        foreach ($data['buckets'] as $bucket) {
+            if ($data['value'] <= $bucket) {
+                $bucketToIncrease = $bucket;
+                break;
+            }
+        }
+
+        // Initialize and increment the bucket
+        apcu_add($this->histogramBucketValueKey($data, $bucketToIncrease), 0);
+        apcu_inc($this->histogramBucketValueKey($data, $bucketToIncrease));
+    }
+
+    public function updateGauge(array $data)
+    {
+        $valueKey = $this->valueKey($data);
+        if ($data['command'] == Adapter::COMMAND_SET) {
+            apcu_store($valueKey, $this->toInteger($data['value']));
+            apcu_store($this->metaKey($data), json_encode($this->metaData($data)));
+        } else {
+            $new = apcu_add($valueKey, $this->toInteger(0));
+            if ($new) {
+                apcu_store($this->metaKey($data), json_encode($this->metaData($data)));
+            }
+            // Taken from https://github.com/prometheus/client_golang/blob/66058aac3a83021948e5fb12f1f408ff556b9037/prometheus/value.go#L91
+            $done = false;
+            while (!$done) {
+                $old = apcu_fetch($valueKey);
+                $done = apcu_cas($valueKey, $old, $this->toInteger($this->fromInteger($old) + $data['value']));
+            }
+        }
+    }
+
+    public function updateCounter(array $data)
+    {
+        $new = apcu_add($this->valueKey($data), 0);
+        if ($new) {
+            apcu_store($this->metaKey($data), json_encode($this->metaData($data)));
+        }
+        apcu_inc($this->valueKey($data), $data['value']);
+    }
+
+    public function flushAPC()
+    {
+       apcu_clear_cache();
+    }
+
+    /**
+     * @param array $data
+     * @return string
+     */
+    private function metaKey(array $data)
+    {
+        return implode(':', array(self::PROMETHEUS_PREFIX, $data['type'], $data['name'], 'meta'));
+    }
+
+    /**
+     * @param array $data
+     * @return string
+     */
+    private function valueKey(array $data)
+    {
+        return implode(':', array(self::PROMETHEUS_PREFIX, $data['type'], $data['name'], json_encode($data['labelValues']), 'value'));
+    }
+
+    /**
+     * @param array $data
+     * @return string
+     */
+    private function histogramBucketValueKey(array $data, $bucket)
+    {
+        return implode(':', array(self::PROMETHEUS_PREFIX, $data['type'], $data['name'], json_encode($data['labelValues']), $bucket, 'value'));
+    }
+
+    /**
+     * @param array $data
+     * @return array
+     */
+    private function metaData(array $data)
+    {
+        $metricsMetaData = $data;
+        unset($metricsMetaData['value']);
+        unset($metricsMetaData['command']);
+        unset($metricsMetaData['labelValues']);
+        return $metricsMetaData;
+    }
+
+    /**
+     * @return array
+     */
+    private function collectCounters()
+    {
+        $counters = array();
+        foreach (new APCUIterator( '/^prom:counter:.*:meta/') as $counter) {
+            $metaData = json_decode($counter['value'], true);
+            $data = array(
+                'name' => $metaData['name'],
+                'help' => $metaData['help'],
+                'type' => $metaData['type'],
+                'labelNames' => $metaData['labelNames'],
+            );
+            foreach (new APCUIterator( '/^prom:counter:' . $metaData['name'] . ':.*:value/') as $value) {
+                $parts = explode(':', $value['key']);
+                $labelValues = $parts[3];
+                $data['samples'][] = array(
+                    'name' => $metaData['name'],
+                    'labelNames' => array(),
+                    'labelValues' => json_decode($labelValues),
+                    'value' => $value['value']
+                );
+            }
+            $this->sortSamples($data['samples']);
+            $counters[] = new MetricFamilySamples($data);
+        }
+        return $counters;
+    }
+
+    /**
+     * @return array
+     */
+    private function collectGauges()
+    {
+        $gauges = array();
+        foreach (new APCUIterator( '/^prom:gauge:.*:meta/') as $gauge) {
+            $metaData = json_decode($gauge['value'], true);
+            $data = array(
+                'name' => $metaData['name'],
+                'help' => $metaData['help'],
+                'type' => $metaData['type'],
+                'labelNames' => $metaData['labelNames'],
+            );
+            foreach (new APCUIterator( '/^prom:gauge:' . $metaData['name'] . ':.*:value/') as $value) {
+                $parts = explode(':', $value['key']);
+                $labelValues = $parts[3];
+                $data['samples'][] = array(
+                    'name' => $metaData['name'],
+                    'labelNames' => array(),
+                    'labelValues' => json_decode($labelValues),
+                    'value' => $this->fromInteger($value['value'])
+                );
+            }
+
+            $this->sortSamples($data['samples']);
+            $gauges[] = new MetricFamilySamples($data);
+        }
+        return $gauges;
+    }
+
+    /**
+     * @return array
+     */
+    private function collectHistograms()
+    {
+        $histograms = array();
+        foreach (new APCUIterator( '/^prom:histogram:.*:meta/') as $histogram) {
+            $metaData = json_decode($histogram['value'], true);
+            $data = array(
+                'name' => $metaData['name'],
+                'help' => $metaData['help'],
+                'type' => $metaData['type'],
+                'labelNames' => $metaData['labelNames'],
+                'buckets' => $metaData['buckets']
+            );
+
+            // Add the Inf bucket so we can compute it later on
+            $data['buckets'][] = '+Inf';
+
+            $histogramBuckets = array();
+            foreach (new APCUIterator( '/^prom:histogram:' . $metaData['name'] . ':.*:value/') as $value) {
+                $parts = explode(':', $value['key']);
+                $labelValues = $parts[3];
+                $bucket = $parts[4];
+                // Key by labelValues
+                $histogramBuckets[$labelValues][$bucket] = $value['value'];
+            }
+
+            // Compute all buckets
+            $labels = array_keys($histogramBuckets);
+            sort($labels);
+            foreach ($labels as $labelValues) {
+                $acc = 0;
+                $decodedLabelValues = json_decode($labelValues);
+                foreach ($data['buckets'] as $bucket) {
+                    $bucket = (string) $bucket;
+                    if (!isset($histogramBuckets[$labelValues][$bucket])) {
+                        $data['samples'][] = array(
+                            'name' => $metaData['name'] . '_bucket',
+                            'labelNames' => array('le'),
+                            'labelValues' => array_merge($decodedLabelValues, array($bucket)),
+                            'value' => $acc
+                        );
+                    } else {
+                        $acc += $histogramBuckets[$labelValues][$bucket];
+                        $data['samples'][] = array(
+                            'name' => $metaData['name'] . '_' . 'bucket',
+                            'labelNames' => array('le'),
+                            'labelValues' => array_merge($decodedLabelValues, array($bucket)),
+                            'value' => $acc
+                        );
+                    }
+                }
+
+                // Add the count
+                $data['samples'][] = array(
+                    'name' => $metaData['name'] . '_count',
+                    'labelNames' => array(),
+                    'labelValues' => $decodedLabelValues,
+                    'value' => $acc
+                );
+
+                // Add the sum
+                $data['samples'][] = array(
+                    'name' => $metaData['name'] . '_sum',
+                    'labelNames' => array(),
+                    'labelValues' => $decodedLabelValues,
+                    'value' => $this->fromInteger($histogramBuckets[$labelValues]['sum'])
+                );
+
+            }
+            $histograms[] = new MetricFamilySamples($data);
+        }
+        return $histograms;
+    }
+
+    /**
+     * @param mixed $val
+     * @return int
+     */
+    private function toInteger($val)
+    {
+        return unpack('Q', pack('d', $val))[1];
+    }
+
+    /**
+     * @param mixed $val
+     * @return int
+     */
+    private function fromInteger($val)
+    {
+        return unpack('d', pack('Q', $val))[1];
+    }
+
+    private function sortSamples(array &$samples)
+    {
+        usort($samples, function($a, $b){
+            return strcmp(implode("", $a['labelValues']), implode("", $b['labelValues']));
+        });
+    }
+}

--- a/tests/Test/Prometheus/APC/CollectorRegistryTest.php
+++ b/tests/Test/Prometheus/APC/CollectorRegistryTest.php
@@ -6,8 +6,12 @@ namespace Test\Prometheus\APC;
 use Prometheus\Storage\APC;
 use Test\Prometheus\AbstractCollectorRegistryTest;
 
+/**
+ * @requires extension apc
+ */
 class CollectorRegistryTest extends AbstractCollectorRegistryTest
 {
+
     public function configureAdapter()
     {
         $this->adapter = new APC();

--- a/tests/Test/Prometheus/APC/CounterTest.php
+++ b/tests/Test/Prometheus/APC/CounterTest.php
@@ -8,10 +8,10 @@ use Test\Prometheus\AbstractCounterTest;
 
 /**
  * See https://prometheus.io/docs/instrumenting/exposition_formats/
+ * @requires extension apc
  */
 class CounterTest extends AbstractCounterTest
 {
-
     public function configureAdapter()
     {
         $this->adapter = new APC();

--- a/tests/Test/Prometheus/APC/GaugeTest.php
+++ b/tests/Test/Prometheus/APC/GaugeTest.php
@@ -8,10 +8,10 @@ use Test\Prometheus\AbstractGaugeTest;
 
 /**
  * See https://prometheus.io/docs/instrumenting/exposition_formats/
+ * @requires extension apc
  */
 class GaugeTest extends AbstractGaugeTest
 {
-
     public function configureAdapter()
     {
         $this->adapter = new APC();

--- a/tests/Test/Prometheus/APC/HistogramTest.php
+++ b/tests/Test/Prometheus/APC/HistogramTest.php
@@ -8,10 +8,10 @@ use Test\Prometheus\AbstractHistogramTest;
 
 /**
  * See https://prometheus.io/docs/instrumenting/exposition_formats/
+ * @requires extension apc
  */
 class HistogramTest extends AbstractHistogramTest
 {
-
     public function configureAdapter()
     {
         $this->adapter = new APC();

--- a/tests/Test/Prometheus/APCu/APCuTest.php
+++ b/tests/Test/Prometheus/APCu/APCuTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Test\Prometheus\APCu;
+
+use Prometheus\Storage\APCu;
+use RuntimeException;
+
+final class APCuTest extends \PHPUnit_Framework_TestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (extension_loaded('apcu')) {
+            $this->markTestSkipped('apcu extension already available');
+            return;
+        }
+
+        if (class_exists(APCUIterator::class)) {
+            $this->markTestSkipped('apcu extension is expected version');
+            return;
+        }
+
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldThrowAnExceptionWhenAPCUExtensionIsNotLoaded()
+    {
+        $this->setExpectedException(RuntimeException::class);
+        $adapter = new APCu();
+    }
+
+}

--- a/tests/Test/Prometheus/APCu/CollectorRegistryTest.php
+++ b/tests/Test/Prometheus/APCu/CollectorRegistryTest.php
@@ -1,0 +1,20 @@
+<?php
+
+
+namespace Test\Prometheus\APCu;
+
+use Prometheus\Storage\APCu;
+use Test\Prometheus\AbstractCollectorRegistryTest;
+
+/**
+ * @requires extension apcu
+ * @requires function APCUIterator::__construct
+ */
+class CollectorRegistryTest extends AbstractCollectorRegistryTest
+{
+    public function configureAdapter()
+    {
+        $this->adapter = new APCu();
+        $this->adapter->flushAPC();
+    }
+}

--- a/tests/Test/Prometheus/APCu/CounterTest.php
+++ b/tests/Test/Prometheus/APCu/CounterTest.php
@@ -1,0 +1,21 @@
+<?php
+
+
+namespace Test\Prometheus\APCu;
+
+use Prometheus\Storage\APCu;
+use Test\Prometheus\AbstractCounterTest;
+
+/**
+ * See https://prometheus.io/docs/instrumenting/exposition_formats/
+ * @requires extension apcu
+ * @requires function APCUIterator::__construct
+ */
+class CounterTest extends AbstractCounterTest
+{
+    public function configureAdapter()
+    {
+        $this->adapter = new APCu();
+        $this->adapter->flushAPC();
+    }
+}

--- a/tests/Test/Prometheus/APCu/GaugeTest.php
+++ b/tests/Test/Prometheus/APCu/GaugeTest.php
@@ -1,0 +1,21 @@
+<?php
+
+
+namespace Test\Prometheus\APCu;
+
+use Prometheus\Storage\APCu;
+use Test\Prometheus\AbstractGaugeTest;
+
+/**
+ * See https://prometheus.io/docs/instrumenting/exposition_formats/
+ * @requires extension apcu
+ * @requires function APCUIterator::__construct
+ */
+class GaugeTest extends AbstractGaugeTest
+{
+    public function configureAdapter()
+    {
+        $this->adapter = new APCu();
+        $this->adapter->flushAPC();
+    }
+}

--- a/tests/Test/Prometheus/APCu/HistogramTest.php
+++ b/tests/Test/Prometheus/APCu/HistogramTest.php
@@ -1,0 +1,22 @@
+<?php
+
+
+namespace Test\Prometheus\APCu;
+
+use Prometheus\Storage\APCu;
+use Test\Prometheus\AbstractHistogramTest;
+
+/**
+ * See https://prometheus.io/docs/instrumenting/exposition_formats/
+ * @requires extension apcu
+ * @requires function APCUIterator::__construct
+ */
+class HistogramTest extends AbstractHistogramTest
+{
+    public function configureAdapter()
+    {
+        $this->adapter = new APCu();
+        $this->adapter->flushAPC();
+    }
+}
+

--- a/tests/Test/Prometheus/Redis/CollectorRegistryTest.php
+++ b/tests/Test/Prometheus/Redis/CollectorRegistryTest.php
@@ -3,9 +3,13 @@
 
 namespace Test\Prometheus\Redis;
 
+use function class_exists;
 use Prometheus\Storage\Redis;
 use Test\Prometheus\AbstractCollectorRegistryTest;
 
+/**
+ * @requires extension redis
+ */
 class CollectorRegistryTest extends AbstractCollectorRegistryTest
 {
     public function configureAdapter()

--- a/tests/Test/Prometheus/Redis/CounterTest.php
+++ b/tests/Test/Prometheus/Redis/CounterTest.php
@@ -8,10 +8,10 @@ use Test\Prometheus\AbstractCounterTest;
 
 /**
  * See https://prometheus.io/docs/instrumenting/exposition_formats/
+ * @requires extension redis
  */
 class CounterTest extends AbstractCounterTest
 {
-
     public function configureAdapter()
     {
         $this->adapter = new Redis(array('host' => REDIS_HOST));

--- a/tests/Test/Prometheus/Redis/GaugeTest.php
+++ b/tests/Test/Prometheus/Redis/GaugeTest.php
@@ -8,10 +8,10 @@ use Test\Prometheus\AbstractGaugeTest;
 
 /**
  * See https://prometheus.io/docs/instrumenting/exposition_formats/
+ * @requires extension redis
  */
 class GaugeTest extends AbstractGaugeTest
 {
-
     public function configureAdapter()
     {
         $this->adapter = new Redis(array('host' => REDIS_HOST));

--- a/tests/Test/Prometheus/Redis/HistogramTest.php
+++ b/tests/Test/Prometheus/Redis/HistogramTest.php
@@ -8,10 +8,10 @@ use Test\Prometheus\AbstractHistogramTest;
 
 /**
  * See https://prometheus.io/docs/instrumenting/exposition_formats/
+ * @requires extension redis
  */
 class HistogramTest extends AbstractHistogramTest
 {
-
     public function configureAdapter()
     {
         $this->adapter = new Redis(array('host' => REDIS_HOST));

--- a/tests/Test/Prometheus/Storage/RedisTest.php
+++ b/tests/Test/Prometheus/Storage/RedisTest.php
@@ -3,7 +3,9 @@
 
 namespace Prometheus\Storage;
 
-
+/**
+ * @requires extension redis
+ */
 class RedisTest extends \PHPUnit_Framework_TestCase
 {
     /**


### PR DESCRIPTION
First of all, apologies to @JWZH for not being able to incorporate his changes in this PR.

Added a new APCu adapter, which is less complex then having one that does both, or adding a polyfill that is not required. I also made test suite a bit more resilient to missing extensions, so instead of crashing it skips tests related to those adapters.