### PR TITLE
Add Interfaces to Boundaries

### DIFF
--- a/src/Prometheus/CollectorRegistry.php
+++ b/src/Prometheus/CollectorRegistry.php
@@ -9,7 +9,7 @@ use Prometheus\Exception\MetricsRegistrationException;
 use Prometheus\Storage\Adapter;
 use Prometheus\Storage\Redis;
 
-class CollectorRegistry
+class CollectorRegistry implements RegistryInterface
 {
     /**
      * @var CollectorRegistry

--- a/src/Prometheus/RegistryInterface.php
+++ b/src/Prometheus/RegistryInterface.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Prometheus;
+
+use Prometheus\Exception\MetricNotFoundException;
+use Prometheus\Exception\MetricsRegistrationException;
+
+interface RegistryInterface
+{
+    /**
+     * @return MetricFamilySamples[]
+     */
+    public function getMetricFamilySamples();
+
+    /**
+     * @param string $namespace e.g. cms
+     * @param string $name e.g. duration_seconds
+     * @param string $help e.g. The duration something took in seconds.
+     * @param array  $labels e.g. ['controller', 'action']
+     *
+     * @return Gauge
+     * @throws MetricsRegistrationException
+     */
+    public function registerGauge($namespace, $name, $help, $labels = []);
+
+    /**
+     * @param string $namespace
+     * @param string $name
+     *
+     * @return Gauge
+     * @throws MetricNotFoundException
+     */
+    public function getGauge($namespace, $name);
+
+    /**
+     * @param string $namespace e.g. cms
+     * @param string $name e.g. duration_seconds
+     * @param string $help e.g. The duration something took in seconds.
+     * @param array  $labels e.g. ['controller', 'action']
+     *
+     * @return Gauge
+     */
+    public function getOrRegisterGauge($namespace, $name, $help, $labels = []);
+
+    /**
+     * @param string $namespace e.g. cms
+     * @param string $name e.g. requests
+     * @param string $help e.g. The number of requests made.
+     * @param array  $labels e.g. ['controller', 'action']
+     *
+     * @return Counter
+     * @throws MetricsRegistrationException
+     */
+    public function registerCounter($namespace, $name, $help, $labels = []);
+
+    /**
+     * @param string $namespace
+     * @param string $name
+     *
+     * @return Counter
+     * @throws MetricNotFoundException
+     */
+    public function getCounter($namespace, $name);
+
+    /**
+     * @param string $namespace e.g. cms
+     * @param string $name e.g. requests
+     * @param string $help e.g. The number of requests made.
+     * @param array  $labels e.g. ['controller', 'action']
+     *
+     * @return Counter
+     */
+    public function getOrRegisterCounter($namespace, $name, $help, $labels = []);
+
+    /**
+     * @param string $namespace e.g. cms
+     * @param string $name e.g. duration_seconds
+     * @param string $help e.g. A histogram of the duration in seconds.
+     * @param array  $labels e.g. ['controller', 'action']
+     * @param array  $buckets e.g. [100, 200, 300]
+     *
+     * @return Histogram
+     * @throws MetricsRegistrationException
+     */
+    public function registerHistogram($namespace, $name, $help, $labels = [], $buckets = null);
+
+    /**
+     * @param string $namespace
+     * @param string $name
+     *
+     * @return Histogram
+     * @throws MetricNotFoundException
+     */
+    public function getHistogram($namespace, $name);
+
+    /**
+     * @param string $namespace e.g. cms
+     * @param string $name e.g. duration_seconds
+     * @param string $help e.g. A histogram of the duration in seconds.
+     * @param array  $labels e.g. ['controller', 'action']
+     * @param array  $buckets e.g. [100, 200, 300]
+     *
+     * @return Histogram
+     */
+    public function getOrRegisterHistogram($namespace, $name, $help, $labels = [], $buckets = null);
+}

--- a/src/Prometheus/RenderTextFormat.php
+++ b/src/Prometheus/RenderTextFormat.php
@@ -3,7 +3,7 @@
 namespace Prometheus;
 
 
-class RenderTextFormat
+class RenderTextFormat implements RendererInterface
 {
     const MIME_TYPE = 'text/plain; version=0.0.4';
 

--- a/src/Prometheus/RendererInterface.php
+++ b/src/Prometheus/RendererInterface.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace Prometheus;
+
+interface RendererInterface
+{
+    /**
+     * @param MetricFamilySamples[] $metrics
+     *
+     * @return string
+     */
+    public function render(array $metrics);
+}


### PR DESCRIPTION
The registry and the rederer are classes that are usually injected by
users into their own code, having interfaces for them allow users to
mock based on the API and not on the concret implementation which avoids
a common code smell. This also allows better custom implementations if
users so desire.