### PR TITLE
Tests for PHP 7 and 7.1, use APCu polyfill

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: php
 php:
   - 5.6
+  - 7.0
+  - 7.1
 
 services:
   - redis-server

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     ],
     "require": {
         "php": ">=5.6.3",
-        "guzzlehttp/guzzle": "^6.2"
+        "guzzlehttp/guzzle": "^6.2",
+        "symfony/polyfill-apcu": "^1.6"
     },
     "require-dev": {
         "phpunit/phpunit": "4.1.0"

--- a/tests/Test/Prometheus/APC/CollectorRegistryTest.php
+++ b/tests/Test/Prometheus/APC/CollectorRegistryTest.php
@@ -6,8 +6,12 @@ namespace Test\Prometheus\APC;
 use Prometheus\Storage\APC;
 use Test\Prometheus\AbstractCollectorRegistryTest;
 
+/**
+ * @requires extension apc
+ */
 class CollectorRegistryTest extends AbstractCollectorRegistryTest
 {
+
     public function configureAdapter()
     {
         $this->adapter = new APC();

--- a/tests/Test/Prometheus/APC/CounterTest.php
+++ b/tests/Test/Prometheus/APC/CounterTest.php
@@ -8,10 +8,10 @@ use Test\Prometheus\AbstractCounterTest;
 
 /**
  * See https://prometheus.io/docs/instrumenting/exposition_formats/
+ * @requires extension apc
  */
 class CounterTest extends AbstractCounterTest
 {
-
     public function configureAdapter()
     {
         $this->adapter = new APC();

--- a/tests/Test/Prometheus/APC/GaugeTest.php
+++ b/tests/Test/Prometheus/APC/GaugeTest.php
@@ -8,10 +8,10 @@ use Test\Prometheus\AbstractGaugeTest;
 
 /**
  * See https://prometheus.io/docs/instrumenting/exposition_formats/
+ * @requires extension apc
  */
 class GaugeTest extends AbstractGaugeTest
 {
-
     public function configureAdapter()
     {
         $this->adapter = new APC();

--- a/tests/Test/Prometheus/APC/HistogramTest.php
+++ b/tests/Test/Prometheus/APC/HistogramTest.php
@@ -8,10 +8,10 @@ use Test\Prometheus\AbstractHistogramTest;
 
 /**
  * See https://prometheus.io/docs/instrumenting/exposition_formats/
+ * @requires extension apc
  */
 class HistogramTest extends AbstractHistogramTest
 {
-
     public function configureAdapter()
     {
         $this->adapter = new APC();

--- a/tests/Test/Prometheus/Redis/CollectorRegistryTest.php
+++ b/tests/Test/Prometheus/Redis/CollectorRegistryTest.php
@@ -3,9 +3,13 @@
 
 namespace Test\Prometheus\Redis;
 
+use function class_exists;
 use Prometheus\Storage\Redis;
 use Test\Prometheus\AbstractCollectorRegistryTest;
 
+/**
+ * @requires extension redis
+ */
 class CollectorRegistryTest extends AbstractCollectorRegistryTest
 {
     public function configureAdapter()

--- a/tests/Test/Prometheus/Redis/CounterTest.php
+++ b/tests/Test/Prometheus/Redis/CounterTest.php
@@ -8,10 +8,10 @@ use Test\Prometheus\AbstractCounterTest;
 
 /**
  * See https://prometheus.io/docs/instrumenting/exposition_formats/
+ * @requires extension redis
  */
 class CounterTest extends AbstractCounterTest
 {
-
     public function configureAdapter()
     {
         $this->adapter = new Redis(array('host' => REDIS_HOST));

--- a/tests/Test/Prometheus/Redis/GaugeTest.php
+++ b/tests/Test/Prometheus/Redis/GaugeTest.php
@@ -8,10 +8,10 @@ use Test\Prometheus\AbstractGaugeTest;
 
 /**
  * See https://prometheus.io/docs/instrumenting/exposition_formats/
+ * @requires extension redis
  */
 class GaugeTest extends AbstractGaugeTest
 {
-
     public function configureAdapter()
     {
         $this->adapter = new Redis(array('host' => REDIS_HOST));

--- a/tests/Test/Prometheus/Redis/HistogramTest.php
+++ b/tests/Test/Prometheus/Redis/HistogramTest.php
@@ -8,10 +8,10 @@ use Test\Prometheus\AbstractHistogramTest;
 
 /**
  * See https://prometheus.io/docs/instrumenting/exposition_formats/
+ * @requires extension redis
  */
 class HistogramTest extends AbstractHistogramTest
 {
-
     public function configureAdapter()
     {
         $this->adapter = new Redis(array('host' => REDIS_HOST));

--- a/tests/Test/Prometheus/Storage/RedisTest.php
+++ b/tests/Test/Prometheus/Storage/RedisTest.php
@@ -3,7 +3,9 @@
 
 namespace Prometheus\Storage;
 
-
+/**
+ * @requires extension redis
+ */
 class RedisTest extends \PHPUnit_Framework_TestCase
 {
     /**


### PR DESCRIPTION
* Enable tests for PHP 7 and 7.1.
* Use `APCu` polyfill. This way the `APC` storage will work for both APC and APCu.

Solves #47, #51 and #60.

PTAL @rdohms @lcobucci

I believe this solves the APC/APCu dilemma sufficiently.

