### PR TITLE
WIP: Store if registry was initialized

### DIFF
--- a/src/Prometheus/CollectorRegistry.php
+++ b/src/Prometheus/CollectorRegistry.php
@@ -50,6 +50,14 @@ class CollectorRegistry
     }
 
     /**
+     * @return boolean
+     */
+    public function initialized()
+    {
+        return $this->storageAdapter->initialized();
+    }
+
+    /**
      * @return MetricFamilySamples[]
      */
     public function getMetricFamilySamples()

--- a/src/Prometheus/Storage/APC.php
+++ b/src/Prometheus/Storage/APC.php
@@ -11,6 +11,14 @@ class APC implements Adapter
     const PROMETHEUS_PREFIX = 'prom';
 
     /**
+     * @return boolean
+     */
+    public function initialized()
+    {
+        return !apc_add(self::PROMETHEUS_PREFIX . ":initialized", true);
+    }
+
+    /**
      * @return MetricFamilySamples[]
      */
     public function collect()

--- a/src/Prometheus/Storage/Adapter.php
+++ b/src/Prometheus/Storage/Adapter.php
@@ -12,6 +12,11 @@ interface Adapter
     const COMMAND_SET = 3;
 
     /**
+     * @return boolean
+     */
+    public function initialized();
+
+    /**
      * @return MetricFamilySamples[]
      */
     public function collect();

--- a/src/Prometheus/Storage/InMemory.php
+++ b/src/Prometheus/Storage/InMemory.php
@@ -11,6 +11,19 @@ class InMemory implements Adapter
     private $counters = [];
     private $gauges = [];
     private $histograms = [];
+    private $initialized = false;
+
+    /**
+     * @return boolean
+     */
+    public function initialized()
+    {
+        if(!$this->initialized){
+            $this->initialized = true;
+            return false;
+        }
+        return $this->initialized;
+    }
 
     /**
      * @return MetricFamilySamples[]
@@ -28,6 +41,7 @@ class InMemory implements Adapter
         $this->counters = [];
         $this->gauges = [];
         $this->histograms = [];
+        $this->initialized = false;
     }
 
     private function collectHistograms()

--- a/src/Prometheus/Storage/Redis.php
+++ b/src/Prometheus/Storage/Redis.php
@@ -19,6 +19,11 @@ class Redis implements Adapter
     private $options;
     private $redis;
 
+    public function initialized()
+    {
+        return $this->redis->getSet(self::$prefix . 'INITIALIZED', 1);
+    }
+
     public function __construct(array $options = array())
     {
         // with php 5.3 we cannot initialize the options directly on the field definition


### PR DESCRIPTION
This code is a work in progress. I'm opening the pull request this early to learn if you'd accept this when it's done?

Prometheus Authors (Brian) recommend to create zero value for metrics
known to exist in the future.

The usage pattern I want to enable is this:
```
$counter = $registry->registerCounter('namespace', 'metric', ['label_name']);
if(!$registry->initialized()){
    foreach($labelValues as $labelValue){
        $counter->incBy(0, [$labelValue]);
    }
}
```

Initialization is valid as for as long as the data exists in the storage
adapter.
