### PR TITLE
Minor enhancement: Adds flush() method as Adapter's interface

### DIFF
--- a/examples/flush_adapter.php
+++ b/examples/flush_adapter.php
@@ -6,12 +6,11 @@ $adapter = $_GET['adapter'];
 if ($adapter === 'redis') {
     define('REDIS_HOST', isset($_SERVER['REDIS_HOST']) ? $_SERVER['REDIS_HOST'] : '127.0.0.1');
 
-    $redisAdapter = new Prometheus\Storage\Redis(array('host' => REDIS_HOST));
-    $redisAdapter->flushRedis();
+    $adapter = new Prometheus\Storage\Redis(array('host' => REDIS_HOST));
 } elseif ($adapter === 'apc') {
-    $apcAdapter = new Prometheus\Storage\APC();
-    $apcAdapter->flushAPC();
+    $adapter = new Prometheus\Storage\APC();
 } elseif ($adapter === 'in-memory') {
-    $inMemoryAdapter = new Prometheus\Storage\InMemory();
-    $inMemoryAdapter->flushMemory();
+    $adapter = new Prometheus\Storage\InMemory();
 }
+
+$adapter->flush();

--- a/src/Prometheus/Storage/APC.php
+++ b/src/Prometheus/Storage/APC.php
@@ -84,6 +84,14 @@ class APC implements Adapter
         apcu_inc($this->valueKey($data), $data['value']);
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    public function flush()
+    {
+        $this->flushAPC();
+    }
+
     public function flushAPC()
     {
        apcu_clear_cache();

--- a/src/Prometheus/Storage/Adapter.php
+++ b/src/Prometheus/Storage/Adapter.php
@@ -21,4 +21,10 @@ interface Adapter
     public function updateGauge(array $data);
 
     public function updateCounter(array $data);
+
+    /**
+     * Flushes contents in hold by underlying adapter
+     * @return void
+     */
+    public function flush();
 }

--- a/src/Prometheus/Storage/InMemory.php
+++ b/src/Prometheus/Storage/InMemory.php
@@ -24,6 +24,14 @@ class InMemory implements Adapter
         return $metrics;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    public function flush()
+    {
+        $this->flushMemory();
+    }
+
     public function flushMemory()
     {
         $this->counters = [];

--- a/src/Prometheus/Storage/Redis.php
+++ b/src/Prometheus/Storage/Redis.php
@@ -59,6 +59,14 @@ class Redis implements Adapter
         self::$prefix = $prefix;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    public function flush()
+    {
+        $this->flushRedis();
+    }
+
     public function flushRedis()
     {
         $this->openConnection();

--- a/tests/Test/Prometheus/APC/CollectorRegistryTest.php
+++ b/tests/Test/Prometheus/APC/CollectorRegistryTest.php
@@ -15,6 +15,6 @@ class CollectorRegistryTest extends AbstractCollectorRegistryTest
     public function configureAdapter()
     {
         $this->adapter = new APC();
-        $this->adapter->flushAPC();
+        $this->adapter->flush();
     }
 }

--- a/tests/Test/Prometheus/APC/CounterTest.php
+++ b/tests/Test/Prometheus/APC/CounterTest.php
@@ -15,6 +15,6 @@ class CounterTest extends AbstractCounterTest
     public function configureAdapter()
     {
         $this->adapter = new APC();
-        $this->adapter->flushAPC();
+        $this->adapter->flush();
     }
 }

--- a/tests/Test/Prometheus/APC/GaugeTest.php
+++ b/tests/Test/Prometheus/APC/GaugeTest.php
@@ -15,6 +15,6 @@ class GaugeTest extends AbstractGaugeTest
     public function configureAdapter()
     {
         $this->adapter = new APC();
-        $this->adapter->flushAPC();
+        $this->adapter->flush();
     }
 }

--- a/tests/Test/Prometheus/APC/HistogramTest.php
+++ b/tests/Test/Prometheus/APC/HistogramTest.php
@@ -15,7 +15,7 @@ class HistogramTest extends AbstractHistogramTest
     public function configureAdapter()
     {
         $this->adapter = new APC();
-        $this->adapter->flushAPC();
+        $this->adapter->flush();
     }
 }
 

--- a/tests/Test/Prometheus/InMemory/CollectorRegistryTest.php
+++ b/tests/Test/Prometheus/InMemory/CollectorRegistryTest.php
@@ -11,6 +11,6 @@ class CollectorRegistryTest extends AbstractCollectorRegistryTest
     public function configureAdapter()
     {
         $this->adapter = new InMemory();
-        $this->adapter->flushMemory();
+        $this->adapter->flush();
     }
 }

--- a/tests/Test/Prometheus/InMemory/CounterTest.php
+++ b/tests/Test/Prometheus/InMemory/CounterTest.php
@@ -15,6 +15,6 @@ class CounterTest extends AbstractCounterTest
     public function configureAdapter()
     {
         $this->adapter = new InMemory();
-        $this->adapter->flushMemory();
+        $this->adapter->flush();
     }
 }

--- a/tests/Test/Prometheus/InMemory/GaugeTest.php
+++ b/tests/Test/Prometheus/InMemory/GaugeTest.php
@@ -15,6 +15,6 @@ class GaugeTest extends AbstractGaugeTest
     public function configureAdapter()
     {
         $this->adapter = new InMemory();
-        $this->adapter->flushMemory();
+        $this->adapter->flush();
     }
 }

--- a/tests/Test/Prometheus/InMemory/HistogramTest.php
+++ b/tests/Test/Prometheus/InMemory/HistogramTest.php
@@ -15,7 +15,7 @@ class HistogramTest extends AbstractHistogramTest
     public function configureAdapter()
     {
         $this->adapter = new InMemory();
-        $this->adapter->flushMemory();
+        $this->adapter->flush();
     }
 }
 

--- a/tests/Test/Prometheus/Redis/CollectorRegistryTest.php
+++ b/tests/Test/Prometheus/Redis/CollectorRegistryTest.php
@@ -15,6 +15,6 @@ class CollectorRegistryTest extends AbstractCollectorRegistryTest
     public function configureAdapter()
     {
         $this->adapter = new Redis(array('host' => REDIS_HOST));
-        $this->adapter->flushRedis();
+        $this->adapter->flush();
     }
 }

--- a/tests/Test/Prometheus/Redis/CounterTest.php
+++ b/tests/Test/Prometheus/Redis/CounterTest.php
@@ -15,6 +15,6 @@ class CounterTest extends AbstractCounterTest
     public function configureAdapter()
     {
         $this->adapter = new Redis(array('host' => REDIS_HOST));
-        $this->adapter->flushRedis();
+        $this->adapter->flush();
     }
 }

--- a/tests/Test/Prometheus/Redis/GaugeTest.php
+++ b/tests/Test/Prometheus/Redis/GaugeTest.php
@@ -15,6 +15,6 @@ class GaugeTest extends AbstractGaugeTest
     public function configureAdapter()
     {
         $this->adapter = new Redis(array('host' => REDIS_HOST));
-        $this->adapter->flushRedis();
+        $this->adapter->flush();
     }
 }

--- a/tests/Test/Prometheus/Redis/HistogramTest.php
+++ b/tests/Test/Prometheus/Redis/HistogramTest.php
@@ -15,6 +15,6 @@ class HistogramTest extends AbstractHistogramTest
     public function configureAdapter()
     {
         $this->adapter = new Redis(array('host' => REDIS_HOST));
-        $this->adapter->flushRedis();
+        $this->adapter->flush();
     }
 }

--- a/tests/Test/Prometheus/Storage/RedisTest.php
+++ b/tests/Test/Prometheus/Storage/RedisTest.php
@@ -16,7 +16,7 @@ class RedisTest extends \PHPUnit_Framework_TestCase
     public function itShouldThrowAnExceptionOnConnectionFailure()
     {
         $redis = new Redis(array('host' => 'doesntexist.test'));
-        $redis->flushRedis();
+        $redis->flush();
     }
 
 }


### PR DESCRIPTION
__Why?__

There could be case, when one would want to flush underlying adapter's contents. Usually one wouldn't do it, but I want to have a way of doing so in case of need(though rare).

For now there were methods but with different names (e.g. flushAPC(), flushRedis() etc.).

__Change log__

This PR adds a consistent interface method for adapters, i.e. flush().

I haven't removed old methods, just calling them from above new method.

---

Awaiting your response on whether this change would be acceptable.