### PR TITLE
Detect if APC is enabled when trying to use APC storage.

### DIFF
--- a/src/Prometheus/Storage/APC.php
+++ b/src/Prometheus/Storage/APC.php
@@ -4,12 +4,23 @@
 namespace Prometheus\Storage;
 
 
+use Prometheus\Exception\StorageException;
 use Prometheus\MetricFamilySamples;
 use RuntimeException;
 
 class APC implements Adapter
 {
     const PROMETHEUS_PREFIX = 'prom';
+
+    /**
+     * @throws StorageException
+     */
+    public function __construct()
+    {
+        if (!ini_get('apc.enabled') || ((php_sapi_name() == 'cli') && !ini_get('apc.enable_cli'))) {
+            throw new StorageException('APC is not enabled');
+        }
+    }
 
     /**
      * @return MetricFamilySamples[]


### PR DESCRIPTION
When we use APC storage there's a chance to get infinite loop if APC was disabled by mistake.
In particular this is happening when you try to update histogram - https://github.com/Jimdo/prometheus_client_php/blob/master/src/Prometheus/Storage/APC.php#L36:
```php
        $done = false;
        while (!$done) {
            $old = apcu_fetch($sumKey);
            $done = apcu_cas($sumKey, $old, $this->toInteger($this->fromInteger($old) + $data['value']));
        }
```
To prevent this we can introduce additional check for APC storage.