### PR TITLE
Flush only metric data from Redis instead of complete server

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "symfony/polyfill-apcu": "^1.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.1.0"
+        "phpunit/phpunit": "~5.7"
     },
     "suggest": {
         "ext-redis": "Required if using Redis.",


### PR DESCRIPTION
**How it currently behaves:**
After the `flushRedis()` method is called, the complete Redis server incl. all databases is flushed using `FLUSHALL`. One dedicated Redis server/cluster is required to use the Redis adapter.

**How it should behave:**
Only the metric data (the keys and the actual metrics) are deleted via a LUA script. A shared Redis server/cluster can be used for collecting metrics using the Redis adapter.

I also switched from PHPUnit 4.1.0 to ~5.7 since >=PHP 5.6.3 is required in the composer file.