### PR TITLE
Fix pushgateway delete method

### DIFF
--- a/src/Prometheus/PushGateway.php
+++ b/src/Prometheus/PushGateway.php
@@ -60,7 +60,7 @@ class PushGateway
      * @param $groupingKey
      * @param $method
      */
-    private function doRequest(CollectorRegistry $collectorRegistry, $job, $groupingKey, $method)
+    private function doRequest(?CollectorRegistry $collectorRegistry, $job, $groupingKey, $method)
     {
         $url = "http://" . $this->address . "/metrics/job/" . $job;
         if (!empty($groupingKey)) {


### PR DESCRIPTION
I got the following error when calling `$pushgateway->delete(...)`:

```
Argument 1 passed to Prometheus\PushGateway::doRequest() must be an instance of Prometheus\CollectorRegistry, null given, called in /.../vendor/jimdo/prometheus_client_php/src/Prometheus/PushGateway.php on line 54
#0 /.../vendor/jimdo/prometheus_client_php/src/Prometheus/PushGateway.php(54): Prometheus\PushGateway->doRequest(NULL, 'resque-php', Array, 'delete') 
...
```

Because delete method was calling doRequest with null $collectorRegistry, but the method definition did not permit it. 

I simple change doRequest to accept null $collectorRegistry. 