### PR TITLE
Updating composer.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: php
 php:
-  - 5.6
   - 7.0
   - 7.1
+  - 7.2
 
 services:
   - redis-server

--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,8 @@
         }
     ],
     "require": {
-        "php": ">=5.6.3",
-        "guzzlehttp/guzzle": "^6.2",
-        "symfony/polyfill-apcu": "^1.6"
+        "php": ">=7.0",
+        "guzzlehttp/guzzle": "^5.3|^6.3"
     },
     "require-dev": {
         "phpunit/phpunit": "4.1.0"


### PR DESCRIPTION
Removing support for PHP 5.6 and upgrading dependency to PHP 7.0
Removing APCu polyfill as it's no longer needed in PHP 7.0
Adding alternative version of guzzle as an option.
This should not break any functionality that lib currently offers.