### PR TITLE
Introduce persistent_id for persistent connections

### DIFF
--- a/src/Prometheus/Storage/Redis.php
+++ b/src/Prometheus/Storage/Redis.php
@@ -41,6 +41,9 @@ class Redis implements Adapter
         if (!isset(self::$defaultOptions['password'])) {
             self::$defaultOptions['password'] = null;
         }
+        if (!isset(self::$defaultOptions['persistent_id'])) {
+            self::$defaultOptions['persistent_id'] = '';
+        }
 
         $this->options = array_merge(self::$defaultOptions, $options);
         $this->redis = new \Redis();
@@ -90,7 +93,7 @@ class Redis implements Adapter
     {
         try {
             if ($this->options['persistent_connections']) {
-                @$this->redis->pconnect($this->options['host'], $this->options['port'], $this->options['timeout']);
+                @$this->redis->pconnect($this->options['host'], $this->options['port'], $this->options['timeout'], $this->options['persistent_id']);
             } else {
                 @$this->redis->connect($this->options['host'], $this->options['port'], $this->options['timeout']);
             }


### PR DESCRIPTION
When using `predis` extension, the underlying library will re-use
connections to same host/port in case of persistent connections. This
becomes an issue when the user's application uses the same host of Redis
but has different databases, meaning that this library will write to
whichever database is previously used by other parts of the code.

Using a persistent id forces the library to create a new connection
that will not conflict with any other connections being used by the
application.