### PR TITLE
Initialize data samples to empty arrays

### DIFF
--- a/src/Prometheus/Storage/APC.php
+++ b/src/Prometheus/Storage/APC.php
@@ -155,6 +155,7 @@ class APC implements Adapter
                 'help' => $metaData['help'],
                 'type' => $metaData['type'],
                 'labelNames' => $metaData['labelNames'],
+                'samples' => array(),
             );
             foreach (new \APCUIterator('/^prom:counter:' . $metaData['name'] . ':.*:value/') as $value) {
                 $parts = explode(':', $value['key']);
@@ -185,6 +186,7 @@ class APC implements Adapter
                 'help' => $metaData['help'],
                 'type' => $metaData['type'],
                 'labelNames' => $metaData['labelNames'],
+                'samples' => array(),
             );
             foreach (new \APCUIterator('/^prom:gauge:' . $metaData['name'] . ':.*:value/') as $value) {
                 $parts = explode(':', $value['key']);
@@ -216,7 +218,8 @@ class APC implements Adapter
                 'help' => $metaData['help'],
                 'type' => $metaData['type'],
                 'labelNames' => $metaData['labelNames'],
-                'buckets' => $metaData['buckets']
+                'buckets' => $metaData['buckets'],
+                'samples' => array(),
             );
 
             // Add the Inf bucket so we can compute it later on

--- a/src/Prometheus/Storage/InMemory.php
+++ b/src/Prometheus/Storage/InMemory.php
@@ -41,7 +41,8 @@ class InMemory implements Adapter
                 'help' => $metaData['help'],
                 'type' => $metaData['type'],
                 'labelNames' => $metaData['labelNames'],
-                'buckets' => $metaData['buckets']
+                'buckets' => $metaData['buckets'],
+                'samples' => array(),
             ];
 
             // Add the Inf bucket so we can compute it later on
@@ -114,6 +115,7 @@ class InMemory implements Adapter
                 'help' => $metaData['help'],
                 'type' => $metaData['type'],
                 'labelNames' => $metaData['labelNames'],
+                'samples' => array(),
             ];
             foreach ($metric['samples'] as $key => $value) {
                 $parts = explode(':', $key);


### PR DESCRIPTION
Fix the error:
```
Argument 1 passed to Prometheus\Storage\APC::sortSamples() must be of the type array, null given, called in /opt/app/vendor/jimdo/prometheus_client_php/src/Prometheus/Storage/APC.php on line 169
```