### PR TITLE
Handle non-existing histogram keys in redis storage

### DIFF
--- a/src/Prometheus/Storage/Redis.php
+++ b/src/Prometheus/Storage/Redis.php
@@ -204,6 +204,10 @@ LUA
     private function collectHistograms()
     {
         $keys = $this->redis->sMembers(self::$prefix . Histogram::TYPE . self::PROMETHEUS_METRIC_KEYS_SUFFIX);
+        if ($keys === false) {
+            return array();
+        }
+
         sort($keys);
         $histograms = array();
         foreach ($keys as $key) {
@@ -278,6 +282,10 @@ LUA
     private function collectGauges()
     {
         $keys = $this->redis->sMembers(self::$prefix . Gauge::TYPE . self::PROMETHEUS_METRIC_KEYS_SUFFIX);
+        if ($keys === false) {
+            return array();
+        }
+
         sort($keys);
         $gauges = array();
         foreach ($keys as $key) {
@@ -304,6 +312,10 @@ LUA
     private function collectCounters()
     {
         $keys = $this->redis->sMembers(self::$prefix . Counter::TYPE . self::PROMETHEUS_METRIC_KEYS_SUFFIX);
+        if ($keys === false) {
+            return array();
+        }
+
         sort($keys);
         $counters = array();
         foreach ($keys as $key) {


### PR DESCRIPTION
Resolves: https://github.com/Jimdo/prometheus_client_php/issues/92