### PR TITLE
Rely on bucket count instead of hIncrByFloat return value

### DIFF
--- a/src/Prometheus/Storage/Redis.php
+++ b/src/Prometheus/Storage/Redis.php
@@ -122,9 +122,9 @@ class Redis implements Adapter
         unset($metaData['value']);
         unset($metaData['labelValues']);
         $this->redis->eval(<<<LUA
-local increment = redis.call('hIncrByFloat', KEYS[1], KEYS[2], ARGV[1])
-redis.call('hIncrBy', KEYS[1], KEYS[3], 1)
-if increment == ARGV[1] then
+redis.call('hIncrByFloat', KEYS[1], KEYS[2], ARGV[1])
+local increment = redis.call('hIncrBy', KEYS[1], KEYS[3], 1)
+if increment == 1 then
     redis.call('hSet', KEYS[1], '__meta', ARGV[2])
     redis.call('sAdd', KEYS[4], KEYS[1])
 end

--- a/tests/Test/Prometheus/AbstractHistogramTest.php
+++ b/tests/Test/Prometheus/AbstractHistogramTest.php
@@ -177,7 +177,7 @@ abstract class AbstractHistogramTest extends PHPUnit_Framework_TestCase
             array(),
             array(0.1, 0.2, 0.3)
         );
-        $histogram->observe(0.11);
+        $histogram->observe(1343.11);
         $histogram->observe(0.3);
         $this->assertThat(
             $this->adapter->collect(),
@@ -200,13 +200,13 @@ abstract class AbstractHistogramTest extends PHPUnit_Framework_TestCase
                                     'name' => 'test_some_metric_bucket',
                                     'labelNames' => array('le'),
                                     'labelValues' => array(0.2),
-                                    'value' => 1,
+                                    'value' => 0,
                                 ),
                                 array(
                                     'name' => 'test_some_metric_bucket',
                                     'labelNames' => array('le'),
                                     'labelValues' => array(0.3),
-                                    'value' => 2,
+                                    'value' => 1,
                                 ),
                                 array(
                                     'name' => 'test_some_metric_bucket',
@@ -224,7 +224,7 @@ abstract class AbstractHistogramTest extends PHPUnit_Framework_TestCase
                                     'name' => 'test_some_metric_sum',
                                     'labelNames' => array(),
                                     'labelValues' => array(),
-                                    'value' => 0.41,
+                                    'value' => 1343.41000000000000003,
                                 )
                             )
                         )


### PR DESCRIPTION
This PR fix problem with floats, sometimes first value in the bucket can be different in PHP and Redis. In this case, the metric key will not be created correctly. Test case can show you more.