### PR TITLE
Bugfix accumulated number of samples in buckets

### DIFF
--- a/src/Prometheus/Storage/APC.php
+++ b/src/Prometheus/Storage/APC.php
@@ -238,22 +238,24 @@ class APC implements Adapter
                 $acc = 0;
                 $decodedLabelValues = $this->decodeLabelValues($labelValues);
                 foreach ($data['buckets'] as $bucket) {
+                    $sampleValue = 0;
                     $bucket = (string) $bucket;
                     if (!isset($histogramBuckets[$labelValues][$bucket])) {
                         $data['samples'][] = array(
                             'name' => $metaData['name'] . '_bucket',
                             'labelNames' => array('le'),
                             'labelValues' => array_merge($decodedLabelValues, array($bucket)),
-                            'value' => $acc
+                            'value' => $sampleValue
                         );
                     } else {
-                        $acc += $histogramBuckets[$labelValues][$bucket];
+                        $sampleValue = $histogramBuckets[$labelValues][$bucket];
                         $data['samples'][] = array(
                             'name' => $metaData['name'] . '_' . 'bucket',
                             'labelNames' => array('le'),
                             'labelValues' => array_merge($decodedLabelValues, array($bucket)),
-                            'value' => $acc
+                            'value' => $sampleValue
                         );
+                        $acc += $sampleValue;
                     }
                 }
 


### PR DESCRIPTION
Previous code accumulated number of samples in bucket from the previous bucket, which resulted in number of samples in any given bucket was equal to the amount of samples that should be in that bucket plus all the samples in the previous bucket.